### PR TITLE
2/18-2/19 arm and superstructure

### DIFF
--- a/src/main/java/frc/robot/Controls.java
+++ b/src/main/java/frc/robot/Controls.java
@@ -8,6 +8,7 @@ import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.wpilibj.GenericHID.RumbleType;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
+import edu.wpi.first.wpilibj2.command.button.RobotModeTriggers;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine.Direction;
 import frc.robot.generated.BonkTunerConstants;
@@ -158,7 +159,7 @@ public class Controls {
     operatorController
         .a()
         .onTrue(superStructure.levelOne(driverController.rightBumper()).withName("level 1"));
-    // driverController.a().onTrue(superStructure.intake());
+    driverController.a().onTrue(superStructure.intake());
     if (sensors.armSensor != null) {
       sensors.armSensor.inTrough().onTrue(superStructure.intake());
     }
@@ -168,6 +169,7 @@ public class Controls {
     if (s.elevatorSubsystem == null) {
       return;
     }
+    RobotModeTriggers.disabled().onTrue(s.elevatorSubsystem.stop());
     // Controls binding goes here
     operatorController
         .leftTrigger()
@@ -221,8 +223,12 @@ public class Controls {
     operatorController
         .leftBumper()
         .onTrue(
-            s.elevatorSubsystem
-                .resetPosZero()
+            Commands.sequence(
+                    Commands.runOnce(
+                        () -> operatorController.setRumble(RumbleType.kBothRumble, 0.5)),
+                    s.elevatorSubsystem.resetPosZero(),
+                    Commands.runOnce(
+                        () -> operatorController.setRumble(RumbleType.kBothRumble, 0.0)))
                 .ignoringDisable(true)
                 .withName("Reset elevator zero"));
   }
@@ -265,6 +271,9 @@ public class Controls {
         .povDown()
         .onTrue(
             s.armPivotSubsystem.moveToPosition(ArmPivot.PRESET_DOWN).withName("SetArmPresetDown"));
+    operatorController
+        .povRight()
+        .onTrue(s.armPivotSubsystem.moveToPosition(ArmPivot.PRESET_OUT).withName("ArmPivotOut"));
   }
 
   private void configureClimbPivotBindings() {

--- a/src/main/java/frc/robot/Controls.java
+++ b/src/main/java/frc/robot/Controls.java
@@ -4,9 +4,9 @@ import static edu.wpi.first.units.Units.*;
 
 import com.ctre.phoenix6.swerve.SwerveModule.DriveRequestType;
 import com.ctre.phoenix6.swerve.SwerveRequest;
+import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.wpilibj.GenericHID.RumbleType;
 import edu.wpi.first.wpilibj2.command.Commands;
-import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine.Direction;
@@ -85,36 +85,44 @@ public class Controls {
     // and Y is defined as to the left according to WPILib convention.
     s.drivebaseSubsystem.setDefaultCommand(
         // s.drivebaseSubsystem will execute this command periodically
-        s.drivebaseSubsystem.applyRequest(
-            () -> {
-              ChassisSpeeds speed = s.drivebaseSubsystem.returnSpeeds();
-              ChassisSpeeds targetSpeeds =
-                  new ChassisSpeeds(
-                      -driverController.getLeftY()
-                          * MaxSpeed, // Drive forward with negative Y (forward)
-                      -driverController.getLeftX() * MaxSpeed, // Drive left with negative X (left)
-                      -driverController.getRightX()
-                          * MaxAngularRate); // Drive counterclockwise with negative X (left)
-              ChassisSpeeds diff = targetSpeeds.minus(speed);
-              double dt = 0.02;
-              // Vx Vy and Omega are really accelerations and not velocities.
-              ChassisSpeeds acceleration = diff.div(dt);
-              double translationAccelMagnitude =
-                  Math.hypot(acceleration.vxMetersPerSecond, acceleration.vyMetersPerSecond);
-              ChassisSpeeds translationLimit =
-                  acceleration.times(Math.min(1, MAX_ACCELERATION / translationAccelMagnitude));
-              ChassisSpeeds rotationLimit =
-                  translationLimit.times(
-                      Math.min(
-                          1, MAX_ROTATION_ACCELERATION / translationLimit.omegaRadiansPerSecond));
-              ChassisSpeeds newSpeeds = speed.times(dt).plus(acceleration);
+        s.drivebaseSubsystem
+            .applyRequest(
+                () -> {
+                  ChassisSpeeds speed = s.drivebaseSubsystem.returnSpeeds();
+                  ChassisSpeeds targetSpeeds =
+                      new ChassisSpeeds(
+                          -driverController.getLeftY()
+                              * MaxSpeed, // Drive forward with negative Y (forward)
+                          -driverController.getLeftX()
+                              * MaxSpeed, // Drive left with negative X (left)
+                          -driverController.getRightX()
+                              * MaxAngularRate); // Drive counterclockwise with negative X (left)
+                  ChassisSpeeds diff = targetSpeeds.minus(speed);
+                  double dt = 0.02;
+                  // Vx Vy and Omega are really accelerations and not velocities.
+                  ChassisSpeeds acceleration = diff.div(dt);
+                  double translationAccelMagnitude =
+                      Math.hypot(acceleration.vxMetersPerSecond, acceleration.vyMetersPerSecond);
+                  ChassisSpeeds translationLimit =
+                      acceleration.times(Math.min(1, MAX_ACCELERATION / translationAccelMagnitude));
+                  ChassisSpeeds rotationLimit =
+                      translationLimit.times(
+                          Math.min(
+                              1,
+                              MAX_ROTATION_ACCELERATION / translationLimit.omegaRadiansPerSecond));
+                  ChassisSpeeds newSpeeds = speed.times(dt).plus(acceleration);
 
-              return drive
-                  .withVelocityX(newSpeeds.vxMetersPerSecond)
-                  .withVelocityY(newSpeeds.vyMetersPerSecond)
-                  .withRotationalRate(newSpeeds.omegaRadiansPerSecond);
-            }).withName("Drive"));
-    s.drivebaseSubsystem.applyRequest(() -> brake).ignoringDisable(true).withName("Brake").schedule();
+                  return drive
+                      .withVelocityX(newSpeeds.vxMetersPerSecond)
+                      .withVelocityY(newSpeeds.vyMetersPerSecond)
+                      .withRotationalRate(newSpeeds.omegaRadiansPerSecond);
+                })
+            .withName("Drive"));
+    s.drivebaseSubsystem
+        .applyRequest(() -> brake)
+        .ignoringDisable(true)
+        .withName("Brake")
+        .schedule();
 
     // driveController.a().whileTrue(s.drivebaseSubsystem.applyRequest(() ->
     // brake));

--- a/src/main/java/frc/robot/Controls.java
+++ b/src/main/java/frc/robot/Controls.java
@@ -173,17 +173,17 @@ public class Controls {
                 .startMovingVoltage(() -> Volts.of(6 * armPivotSpinnyClawController.getLeftY()))
                 .withName("ManuallyMoveArm"));
     armPivotSpinnyClawController
-        .povUp()
+        .povRight()
         .onTrue(s.armPivotSubsystem.moveToPosition(ArmPivot.PRESET_L4).withName("SetArmPresetL4"));
     armPivotSpinnyClawController
         .povLeft()
         .onTrue(
             s.armPivotSubsystem.moveToPosition(ArmPivot.PRESET_L2_L3).withName("SetArmPresetL2_3"));
     armPivotSpinnyClawController
-        .povDown()
+        .povUp()
         .onTrue(s.armPivotSubsystem.moveToPosition(ArmPivot.PRESET_UP).withName("SetArmPresetUp"));
     armPivotSpinnyClawController
-        .povRight()
+        .povDown()
         .onTrue(
             s.armPivotSubsystem.moveToPosition(ArmPivot.PRESET_DOWN).withName("SetArmPresetDown"));
   }

--- a/src/main/java/frc/robot/Controls.java
+++ b/src/main/java/frc/robot/Controls.java
@@ -223,12 +223,12 @@ public class Controls {
     operatorController
         .leftBumper()
         .onTrue(
-            Commands.sequence(
-                    Commands.runOnce(
-                        () -> operatorController.setRumble(RumbleType.kBothRumble, 0.5)),
+            Commands.parallel(
                     s.elevatorSubsystem.resetPosZero(),
-                    Commands.runOnce(
-                        () -> operatorController.setRumble(RumbleType.kBothRumble, 0.0)))
+                    Commands.startEnd(
+                            () -> operatorController.setRumble(RumbleType.kBothRumble, 0.5),
+                            () -> operatorController.setRumble(RumbleType.kBothRumble, 0))
+                        .withTimeout(0.3))
                 .ignoringDisable(true)
                 .withName("Reset elevator zero"));
   }

--- a/src/main/java/frc/robot/Controls.java
+++ b/src/main/java/frc/robot/Controls.java
@@ -110,7 +110,7 @@ public class Controls {
                           Math.min(
                               1,
                               MAX_ROTATION_ACCELERATION / translationLimit.omegaRadiansPerSecond));
-                  ChassisSpeeds newSpeeds = speed.times(dt).plus(acceleration);
+                  ChassisSpeeds newSpeeds = speed.plus(acceleration.times(dt));
 
                   return drive
                       .withVelocityX(newSpeeds.vxMetersPerSecond)

--- a/src/main/java/frc/robot/Controls.java
+++ b/src/main/java/frc/robot/Controls.java
@@ -11,23 +11,26 @@ import frc.robot.generated.BonkTunerConstants;
 import frc.robot.generated.CompTunerConstants;
 import frc.robot.subsystems.ArmPivot;
 import frc.robot.subsystems.ElevatorSubsystem;
+import frc.robot.subsystems.SuperStructure;
 import frc.robot.util.RobotType;
 
 public class Controls {
   private static final int DRIVER_CONTROLLER_PORT = 0;
   private static final int OPERATOR_CONTROLLER_PORT = 1;
-  private static final int THIRD_CONTROLLER_PORT = 2;
+  private static final int ARM_PIVOT_SPINNY_CLAW_CONTROLLER_PORT = 2;
+  private static final int ELEVATOR_CONTROLLER_PORT = 3;
 
-  @SuppressWarnings("UnusedVariable")
   private final CommandXboxController driverController;
 
-  @SuppressWarnings("UnusedVariable")
   private final CommandXboxController operatorController;
 
-  private final CommandXboxController secretThirdController;
+  private final CommandXboxController armPivotSpinnyClawController;
 
-  @SuppressWarnings("UnusedVariable")
+  private final CommandXboxController elevatorTestController;
+
   private final Subsystems s;
+  private final Sensors sensors;
+  private final SuperStructure superStructure;
 
   // Swerve stuff
   private double MaxSpeed =
@@ -51,16 +54,20 @@ public class Controls {
 
   private final Telemetry logger = new Telemetry(MaxSpeed);
 
-  public Controls(Subsystems s) {
+  public Controls(Subsystems s, Sensors sensors, SuperStructure superStructure) {
     driverController = new CommandXboxController(DRIVER_CONTROLLER_PORT);
     operatorController = new CommandXboxController(OPERATOR_CONTROLLER_PORT);
-    secretThirdController = new CommandXboxController(THIRD_CONTROLLER_PORT);
+    armPivotSpinnyClawController = new CommandXboxController(ARM_PIVOT_SPINNY_CLAW_CONTROLLER_PORT);
+    elevatorTestController = new CommandXboxController(ELEVATOR_CONTROLLER_PORT);
     this.s = s;
+    this.sensors = sensors;
+    this.superStructure = superStructure;
     configureDrivebaseBindings();
     configureElevatorBindings();
     configureArmPivotBindings();
     configureClimbPivotBindings();
     configureSpinnyClawBindings();
+    configureSuperStructureBindings();
     configureElevatorLEDBindings();
   }
 
@@ -102,32 +109,47 @@ public class Controls {
     s.drivebaseSubsystem.registerTelemetry(logger::telemeterize);
   }
 
+  private void configureSuperStructureBindings() {
+    if (superStructure == null) {
+      return;
+    }
+    // operator start button used for climb - bound in climb bindings
+    operatorController.y().onTrue(superStructure.levelFour(driverController.rightBumper()));
+    operatorController.x().onTrue(superStructure.levelThree(driverController.rightBumper()));
+    operatorController.b().onTrue(superStructure.levelTwo(driverController.rightBumper()));
+    operatorController.a().onTrue(superStructure.levelOne(driverController.rightBumper()));
+    driverController.a().onTrue(superStructure.intake());
+    if (sensors.armSensor != null) {
+      sensors.armSensor.inTrough().onTrue(superStructure.intake());
+    }
+  }
+
   private void configureElevatorBindings() {
     if (s.elevatorSubsystem == null) {
       return;
     }
-    // Controls binding goes here
-    operatorController.leftTrigger().whileTrue(s.elevatorSubsystem.goUpPower());
-    operatorController.rightTrigger().whileTrue(s.elevatorSubsystem.goDownPower());
-    operatorController
+    // Elevator Controls binding goes here
+    elevatorTestController.leftTrigger().whileTrue(s.elevatorSubsystem.goUpPower());
+    elevatorTestController.rightTrigger().whileTrue(s.elevatorSubsystem.goDownPower());
+    elevatorTestController
         .y()
         .onTrue(
             s.elevatorSubsystem.setLevel(ElevatorSubsystem.LEVEL_FOUR_POS).withName("Elevator L4"));
-    operatorController
+    elevatorTestController
         .x()
         .onTrue(
             s.elevatorSubsystem
                 .setLevel(ElevatorSubsystem.LEVEL_THREE_POS)
                 .withName("Elevator L3"));
-    operatorController
+    elevatorTestController
         .b()
         .onTrue(
             s.elevatorSubsystem.setLevel(ElevatorSubsystem.LEVEL_TWO_POS).withName("Elevator L2"));
-    operatorController
+    elevatorTestController
         .a()
         .onTrue(
             s.elevatorSubsystem.setLevel(ElevatorSubsystem.LEVEL_ONE_POS).withName("Elevator L1"));
-    operatorController
+    elevatorTestController
         .rightBumper()
         .onTrue(
             s.elevatorSubsystem.setLevel(ElevatorSubsystem.INTAKE).withName("Elevator IntakePos"));
@@ -148,17 +170,17 @@ public class Controls {
     // s.armPivotSubsystem
     // .startMovingVoltage(() -> Volts.of(6 * secretThirdController.getLeftY()))
     // .withName("ManuallyMoveArm"));
-    secretThirdController
+    armPivotSpinnyClawController
         .povUp()
         .onTrue(s.armPivotSubsystem.moveToPosition(ArmPivot.PRESET_L4).withName("SetArmPresetL4"));
-    secretThirdController
+    armPivotSpinnyClawController
         .povLeft()
         .onTrue(
             s.armPivotSubsystem.moveToPosition(ArmPivot.PRESET_L2_L3).withName("SetArmPresetL2_3"));
-    secretThirdController
+    armPivotSpinnyClawController
         .povDown()
         .onTrue(s.armPivotSubsystem.moveToPosition(ArmPivot.PRESET_UP).withName("SetArmPresetUp"));
-    secretThirdController
+    armPivotSpinnyClawController
         .povRight()
         .onTrue(
             s.armPivotSubsystem.moveToPosition(ArmPivot.PRESET_DOWN).withName("SetArmPresetDown"));
@@ -177,10 +199,10 @@ public class Controls {
       return;
     }
     // Claw controls bindings go here
-    operatorController
+    armPivotSpinnyClawController
         .rightBumper()
         .whileTrue(s.spinnyClawSubsytem.movingVoltage(() -> Volts.of(9)));
-    operatorController
+    armPivotSpinnyClawController
         .leftBumper()
         .whileTrue(s.spinnyClawSubsytem.movingVoltage(() -> Volts.of(-9)));
   }

--- a/src/main/java/frc/robot/Controls.java
+++ b/src/main/java/frc/robot/Controls.java
@@ -166,10 +166,12 @@ public class Controls {
     }
 
     // Arm Controls binding goes here
-    // s.armPivotSubsystem.setDefaultCommand(
-    // s.armPivotSubsystem
-    // .startMovingVoltage(() -> Volts.of(6 * secretThirdController.getLeftY()))
-    // .withName("ManuallyMoveArm"));
+    armPivotSpinnyClawController
+        .leftStick()
+        .whileTrue(
+            s.armPivotSubsystem
+                .startMovingVoltage(() -> Volts.of(6 * armPivotSpinnyClawController.getLeftY()))
+                .withName("ManuallyMoveArm"));
     armPivotSpinnyClawController
         .povUp()
         .onTrue(s.armPivotSubsystem.moveToPosition(ArmPivot.PRESET_L4).withName("SetArmPresetL4"));

--- a/src/main/java/frc/robot/Controls.java
+++ b/src/main/java/frc/robot/Controls.java
@@ -82,20 +82,26 @@ public class Controls {
     // and Y is defined as to the left according to WPILib convention.
     s.drivebaseSubsystem.setDefaultCommand(
         // s.drivebaseSubsystem will execute this command periodically
-        s.drivebaseSubsystem.applyRequest(
-            () ->
-                drive
-                    .withVelocityX(
-                        -driverController.getLeftY()
-                            * MaxSpeed) // Drive forward with negative Y (forward)
-                    .withVelocityY(
-                        -driverController.getLeftX()
-                            * MaxSpeed) // Drive left with negative X (left)
-                    .withRotationalRate(
-                        -driverController.getRightX()
-                            * MaxAngularRate) // Drive counterclockwise with negative X (left)
-            ));
-    s.drivebaseSubsystem.applyRequest(() -> brake).ignoringDisable(true).schedule();
+        s.drivebaseSubsystem
+            .applyRequest(
+                () ->
+                    drive
+                        .withVelocityX(
+                            -driverController.getLeftY()
+                                * MaxSpeed) // Drive forward with negative Y (forward)
+                        .withVelocityY(
+                            -driverController.getLeftX()
+                                * MaxSpeed) // Drive left with negative X (left)
+                        .withRotationalRate(
+                            -driverController.getRightX()
+                                * MaxAngularRate) // Drive counterclockwise with negative X (left)
+                )
+            .withName("Drive"));
+    s.drivebaseSubsystem
+        .applyRequest(() -> brake)
+        .ignoringDisable(true)
+        .withName("Brake")
+        .schedule();
 
     // driveController.a().whileTrue(s.drivebaseSubsystem.applyRequest(() ->
     // brake));
@@ -107,7 +113,10 @@ public class Controls {
     // reset the field-centric heading on back button press
     driverController
         .back()
-        .onTrue(s.drivebaseSubsystem.runOnce(() -> s.drivebaseSubsystem.seedFieldCentric()));
+        .onTrue(
+            s.drivebaseSubsystem
+                .runOnce(() -> s.drivebaseSubsystem.seedFieldCentric())
+                .withName("Reset gyro"));
     s.drivebaseSubsystem.registerTelemetry(logger::telemeterize);
   }
 
@@ -128,7 +137,7 @@ public class Controls {
     operatorController
         .a()
         .onTrue(superStructure.levelOne(driverController.rightBumper()).withName("level 1"));
-    driverController.a().onTrue(superStructure.intake());
+    // driverController.a().onTrue(superStructure.intake());
     if (sensors.armSensor != null) {
       sensors.armSensor.inTrough().onTrue(superStructure.intake());
     }
@@ -219,7 +228,7 @@ public class Controls {
         .leftStick()
         .whileTrue(
             s.armPivotSubsystem
-                .startMovingVoltage(() -> Volts.of(6 * armPivotSpinnyClawController.getLeftY()))
+                .startMovingVoltage(() -> Volts.of(3 * armPivotSpinnyClawController.getLeftY()))
                 .withName("ManuallyMoveArm"));
     armPivotSpinnyClawController
         .povRight()
@@ -250,12 +259,10 @@ public class Controls {
       return;
     }
     // Claw controls bindings go here
-    armPivotSpinnyClawController
-        .rightBumper()
-        .whileTrue(s.spinnyClawSubsytem.movingVoltage(() -> Volts.of(9)));
-    armPivotSpinnyClawController
-        .leftBumper()
-        .whileTrue(s.spinnyClawSubsytem.movingVoltage(() -> Volts.of(-9)));
+    armPivotSpinnyClawController.rightBumper().whileTrue(s.spinnyClawSubsytem.holdExtakePower());
+    armPivotSpinnyClawController.leftBumper().whileTrue(s.spinnyClawSubsytem.holdIntakePower());
+    driverController.leftTrigger().whileTrue(s.spinnyClawSubsytem.holdExtakePower());
+    driverController.rightTrigger().whileTrue(s.spinnyClawSubsytem.holdIntakePower());
   }
 
   private void configureElevatorLEDBindings() {

--- a/src/main/java/frc/robot/Controls.java
+++ b/src/main/java/frc/robot/Controls.java
@@ -8,6 +8,7 @@ import edu.wpi.first.wpilibj.GenericHID.RumbleType;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
+import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine.Direction;
 import frc.robot.generated.BonkTunerConstants;
 import frc.robot.generated.CompTunerConstants;
 import frc.robot.subsystems.ArmPivot;
@@ -202,6 +203,18 @@ public class Controls {
     }
 
     // Arm Controls binding goes here
+    armPivotSpinnyClawController
+        .a()
+        .whileTrue(s.armPivotSubsystem.SysIDDynamic(Direction.kForward));
+    armPivotSpinnyClawController
+        .b()
+        .whileTrue(s.armPivotSubsystem.SysIDDynamic(Direction.kReverse));
+    armPivotSpinnyClawController
+        .x()
+        .whileTrue(s.armPivotSubsystem.SysIDQuasistatic(Direction.kForward));
+    armPivotSpinnyClawController
+        .y()
+        .whileTrue(s.armPivotSubsystem.SysIDQuasistatic(Direction.kReverse));
     armPivotSpinnyClawController
         .leftStick()
         .whileTrue(

--- a/src/main/java/frc/robot/Hardware.java
+++ b/src/main/java/frc/robot/Hardware.java
@@ -18,6 +18,7 @@ public class Hardware {
 
   // arm pivot [30-34]
   public static final int ARM_PIVOT_MOTOR_ID = 30;
+  public static final int ARM_PIVOT_CANDI_ID = 31;
 
   // climb [50-59]
   public static final int CLIMB_PIVOT_MOTOR_ONE_ID = 50;

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -11,6 +11,9 @@ import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.livewindow.LiveWindow;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
+import frc.robot.Sensors.SensorConstants;
+import frc.robot.Subsystems.SubsystemConstants;
+import frc.robot.subsystems.SuperStructure;
 import frc.robot.util.BuildInfo;
 import frc.robot.util.RobotType;
 
@@ -27,6 +30,7 @@ public class Robot extends TimedRobot {
   public final Controls controls;
   public final Subsystems subsystems;
   public final Sensors sensors;
+  public final SuperStructure superStructure;
 
   protected Robot() {
     // non public for singleton. Protected so test class can subclass
@@ -36,8 +40,21 @@ public class Robot extends TimedRobot {
     LiveWindow.disableAllTelemetry();
 
     subsystems = new Subsystems();
-    controls = new Controls(subsystems);
     sensors = new Sensors();
+    if (SubsystemConstants.ELEVATOR_ENABLED
+        && SubsystemConstants.ARMPIVOT_ENABLED
+        && SubsystemConstants.SPINNYCLAW_ENABLED
+        && SensorConstants.ARMSENSOR_ENABLED) {
+      superStructure =
+          new SuperStructure(
+              subsystems.elevatorSubsystem,
+              subsystems.armPivotSubsystem,
+              subsystems.spinnyClawSubsytem,
+              sensors.armSensor);
+    } else {
+      superStructure = null;
+    }
+    controls = new Controls(subsystems, sensors, superStructure);
 
     SmartDashboard.putString("current bot", robotType.toString());
     SmartDashboard.putData("commandScheduler", CommandScheduler.getInstance());

--- a/src/main/java/frc/robot/Subsystems.java
+++ b/src/main/java/frc/robot/Subsystems.java
@@ -21,7 +21,7 @@ public class Subsystems {
     public static final boolean DRIVEBASE_ENABLED = false;
     public static final boolean VISION_ENABLED = false;
     public static final boolean ELEVATOR_ENABLED = false;
-    public static final boolean ARMPIVOT_ENABLED = false;
+    public static final boolean ARMPIVOT_ENABLED = true;
     public static final boolean SPINNYCLAW_ENABLED = false;
     public static final boolean CLIMBPIVOT_ENABLED = false;
     public static final boolean ELEVATOR_LED_ENABLED = false;

--- a/src/main/java/frc/robot/Subsystems.java
+++ b/src/main/java/frc/robot/Subsystems.java
@@ -22,7 +22,7 @@ public class Subsystems {
     public static final boolean VISION_ENABLED = false;
     public static final boolean ELEVATOR_ENABLED = true;
     public static final boolean ARMPIVOT_ENABLED = true;
-    public static final boolean SPINNYCLAW_ENABLED = false;
+    public static final boolean SPINNYCLAW_ENABLED = true;
     public static final boolean CLIMBPIVOT_ENABLED = false;
     public static final boolean ELEVATOR_LED_ENABLED = false;
   }

--- a/src/main/java/frc/robot/sensors/ArmSensor.java
+++ b/src/main/java/frc/robot/sensors/ArmSensor.java
@@ -1,15 +1,22 @@
 package frc.robot.sensors;
 
 import static edu.wpi.first.units.Units.Millimeter;
+import static edu.wpi.first.units.Units.Millimeters;
 
 import au.grapplerobotics.ConfigurationFailedException;
 import au.grapplerobotics.LaserCan;
 import edu.wpi.first.units.measure.Distance;
+import edu.wpi.first.wpilibj2.command.button.Trigger;
 import frc.robot.Hardware;
+import java.util.function.BooleanSupplier;
 
 public class ArmSensor {
 
   private final LaserCan mainSensor;
+  private static final double TROUGH_LOWER_LIMIT = 250; // untested guess value (in millimeters)
+  private static final double TROUGH_UPPER_LIMIT = 350; // untested guess value
+  private static final double CLAW_LOWER_LIMIT = 30; // untested guess value
+  private static final double CLAW_UPPER_LIMIT = 130; // untested guess value
 
   public ArmSensor() {
     mainSensor = new LaserCan(Hardware.MAIN_ARM_SENSOR);
@@ -33,5 +40,28 @@ public class ArmSensor {
     } else {
       return Millimeter.of(-1);
     }
+  }
+
+  public Trigger inTrough() {
+    return new Trigger(
+        () -> {
+          if (getSensorDistance().in(Millimeters) > TROUGH_LOWER_LIMIT
+              && getSensorDistance().in(Millimeters) < TROUGH_UPPER_LIMIT) {
+            return true;
+          } else {
+            return false;
+          }
+        });
+  }
+
+  public BooleanSupplier inClaw() {
+    return () -> {
+      if (getSensorDistance().in(Millimeters) > CLAW_LOWER_LIMIT
+          && getSensorDistance().in(Millimeters) < CLAW_UPPER_LIMIT) {
+        return true;
+      } else {
+        return false;
+      }
+    };
   }
 }

--- a/src/main/java/frc/robot/subsystems/ArmPivot.java
+++ b/src/main/java/frc/robot/subsystems/ArmPivot.java
@@ -2,11 +2,7 @@ package frc.robot.subsystems;
 
 import static edu.wpi.first.units.Units.Volts;
 
-import com.ctre.phoenix6.configs.CurrentLimitsConfigs;
-import com.ctre.phoenix6.configs.FeedbackConfigs;
-import com.ctre.phoenix6.configs.MotionMagicConfigs;
-import com.ctre.phoenix6.configs.MotorOutputConfigs;
-import com.ctre.phoenix6.configs.Slot0Configs;
+import com.ctre.phoenix6.configs.TalonFXConfiguration;
 import com.ctre.phoenix6.configs.TalonFXConfigurator;
 import com.ctre.phoenix6.controls.MotionMagicVoltage;
 import com.ctre.phoenix6.hardware.TalonFX;
@@ -112,47 +108,43 @@ public class ArmPivot extends SubsystemBase {
   // TalonFX config
   public void factoryDefaults() {
     TalonFXConfigurator cfg = motor.getConfigurator();
-    var feedback_configs = new FeedbackConfigs();
-    feedback_configs.FeedbackRemoteSensorID = Hardware.ARM_PIVOT_CANDI_ID;
-    feedback_configs.FeedbackSensorSource = FeedbackSensorSourceValue.RemoteCANdiPWM1;
+    var talonFXConfiguration = new TalonFXConfiguration();
 
-    cfg.apply(feedback_configs);
+    talonFXConfiguration.Feedback.FeedbackRemoteSensorID = Hardware.ARM_PIVOT_CANDI_ID;
+    talonFXConfiguration.Feedback.FeedbackSensorSource = FeedbackSensorSourceValue.RemoteCANdiPWM1;
 
-    MotorOutputConfigs motorOutputConfiguration = new MotorOutputConfigs();
+    talonFXConfiguration.MotorOutput.NeutralMode = NeutralModeValue.Brake;
 
-    motorOutputConfiguration.NeutralMode = NeutralModeValue.Brake;
-
-    // configuration.ClosedLoopGeneral.ContinuousWrap = true;
-    cfg.apply(motorOutputConfiguration);
     // enabling current limits
-    var currentLimits = new CurrentLimitsConfigs();
-    currentLimits.StatorCurrentLimit = 20; // starting low for testing
-    currentLimits.StatorCurrentLimitEnable = true;
-    currentLimits.SupplyCurrentLimit = 10; // starting low for testing
-    currentLimits.SupplyCurrentLimitEnable = true;
-    cfg.apply(currentLimits);
+    talonFXConfiguration.CurrentLimits.StatorCurrentLimit = 20; // starting low for testing
+    talonFXConfiguration.CurrentLimits.StatorCurrentLimitEnable = true;
+    talonFXConfiguration.CurrentLimits.SupplyCurrentLimit = 10; // starting low for testing
+    talonFXConfiguration.CurrentLimits.SupplyCurrentLimitEnable = true;
 
     // PID
-    var slot0Configs = new Slot0Configs();
     // set slot 0 gains
-    slot0Configs.kS = ARMPIVOT_KS; // Add 0.25 V output to overcome static friction
-    slot0Configs.kV = ARMPIVOT_KV; // A velocity target of 1 rps results in 0.12 V output
-    slot0Configs.kA = ARMPIVOT_KA; // An acceleration of 1 rps/s requires 0.01 V output
-    slot0Configs.kP = ARMPIVOT_KP; // A position error of 2.5 rotations results in 12 V output
-    slot0Configs.kI = ARMPIVOT_KI; // no output for integrated error
-    slot0Configs.kD = ARMPIVOT_KD; // A velocity error of 1 rps results in 0.1 V output
-    slot0Configs.kG = ARMPIVOT_KG; // Gravity feedforward
-    slot0Configs.GravityType = GravityTypeValue.Arm_Cosine;
-    cfg.apply(slot0Configs);
+    talonFXConfiguration.Slot0.kS = ARMPIVOT_KS; // Add 0.25 V output to overcome static friction
+    talonFXConfiguration.Slot0.kV =
+        ARMPIVOT_KV; // A velocity target of 1 rps results in 0.12 V output
+    talonFXConfiguration.Slot0.kA =
+        ARMPIVOT_KA; // An acceleration of 1 rps/s requires 0.01 V output
+    talonFXConfiguration.Slot0.kP =
+        ARMPIVOT_KP; // A position error of 2.5 rotations results in 12 V output
+    talonFXConfiguration.Slot0.kI = ARMPIVOT_KI; // no output for integrated error
+    talonFXConfiguration.Slot0.kD =
+        ARMPIVOT_KD; // A velocity error of 1 rps results in 0.1 V output
+    talonFXConfiguration.Slot0.kG = ARMPIVOT_KG; // Gravity feedforward
+    talonFXConfiguration.Slot0.GravityType = GravityTypeValue.Arm_Cosine;
 
     // set Motion Magic settings in rps not mechanism units
-    var motionMagicConfigs = new MotionMagicConfigs();
-    motionMagicConfigs.MotionMagicCruiseVelocity = (80); // Target cruise velocity of 80 rps
-    motionMagicConfigs.MotionMagicAcceleration =
+    talonFXConfiguration.MotionMagic.MotionMagicCruiseVelocity =
+        (80); // Target cruise velocity of 80 rps
+    talonFXConfiguration.MotionMagic.MotionMagicAcceleration =
         160; // Target acceleration of 160 rps/s (0.5 seconds)
-    motionMagicConfigs.MotionMagicJerk = 1600; // Target jerk of 1600 rps/s/s (0.1 seconds)
-    cfg.apply(motionMagicConfigs);
+    talonFXConfiguration.MotionMagic.MotionMagicJerk =
+        1600; // Target jerk of 1600 rps/s/s (0.1 seconds)
 
+    cfg.apply(talonFXConfiguration);
     motor.setPosition(0);
   }
 }

--- a/src/main/java/frc/robot/subsystems/ArmPivot.java
+++ b/src/main/java/frc/robot/subsystems/ArmPivot.java
@@ -35,6 +35,7 @@ public class ArmPivot extends SubsystemBase {
   public static final double PRESET_L4 = 0.0;
   public static final double PRESET_PRE_L4 = 1.0 / 16.0;
   public static final double PRESET_STOWED = 0.125;
+  public static final double PRESET_OUT = 0;
   public static final double PRESET_UP = 0.25; // Pointing Directly upwards
   public static final double PRESET_DOWN = -0.25;
   public static final double HARDSTOP_HIGH = 0.32;

--- a/src/main/java/frc/robot/subsystems/ArmPivot.java
+++ b/src/main/java/frc/robot/subsystems/ArmPivot.java
@@ -26,14 +26,14 @@ public class ArmPivot extends SubsystemBase {
   private final double ARMPIVOT_KV = 0.12;
   private final double ARMPIVOT_KG = 0;
   private final double ARMPIVOT_KA = 0.01;
-  public static final double PRESET_L1 = 0.0; // This is at position perpendicular to elevator
-  public static final double PRESET_L2_L3 = 45.0;
-  public static final double PRESET_L4 = 0.0;
-  public static final double PRESET_UP = 90.0; // Pointing Directly upwards
-  public static final double PRESET_DOWN = -90.0;
-  public static final double HARDSTOP_HIGH = 95.0;
-  public static final double HARDSTOP_LOW = -95.0;
-  public static final double POS_TOLERANCE = 1.0;
+  public static final double PRESET_L1 = 0.3; // This is at position perpendicular to elevator
+  public static final double PRESET_L2_L3 = 0.38;
+  public static final double PRESET_L4 = 0.3;
+  public static final double PRESET_UP = 0.55; // Pointing Directly upwards
+  public static final double PRESET_DOWN = 0.06;
+  public static final double HARDSTOP_HIGH = 0.63;
+  public static final double HARDSTOP_LOW = 0.05;
+  public static final double POS_TOLERANCE = 0.01;
   public static final double PLACEHOLDER_CORAL_WEIGHT_KG = 0.8;
   // Constant for gear ratio (the power that one motor gives to gear)
   private static final double ARM_RATIO = 360 * (12.0 / 60.0) * (20.0 / 60.0) * (18.0 / 48.0);

--- a/src/main/java/frc/robot/subsystems/ArmPivot.java
+++ b/src/main/java/frc/robot/subsystems/ArmPivot.java
@@ -88,11 +88,7 @@ public class ArmPivot extends SubsystemBase {
     // double
     return setTargetPosition(position)
         .andThen(
-            Commands.waitUntil(
-                () -> {
-                  System.out.println("gotta go fast");
-                  return Math.abs(getCurrentPosition() - position) < POS_TOLERANCE;
-                }));
+            Commands.waitUntil(() -> Math.abs(getCurrentPosition() - position) < POS_TOLERANCE));
   }
 
   // (+) is to move arm up, and (-) is down
@@ -102,12 +98,12 @@ public class ArmPivot extends SubsystemBase {
 
   // logging
   public void logTabs() {
-    Shuffleboard.getTab("pivot-info")
-        .addDouble("pivot_speed", () -> motor.getVelocity().getValueAsDouble());
-    Shuffleboard.getTab("pivot-info")
-        .addDouble("pivot_motor_temp", () -> motor.getDeviceTemp().getValueAsDouble());
-    Shuffleboard.getTab("pivot-info").addDouble("pivot_position", () -> getCurrentPosition());
-    Shuffleboard.getTab("pivot-info").addDouble("pivot_target_position", () -> getTargetPosition());
+    Shuffleboard.getTab("Arm Pivot")
+        .addDouble("Pivot Speed", () -> motor.getVelocity().getValueAsDouble());
+    Shuffleboard.getTab("Arm Pivot")
+        .addDouble("Pivot Motor Temperature", () -> motor.getDeviceTemp().getValueAsDouble());
+    Shuffleboard.getTab("Arm Pivot").addDouble("Pivot Position", () -> getCurrentPosition());
+    Shuffleboard.getTab("Arm Pivot").addDouble("Pivot Target Pos", () -> getTargetPosition());
   }
 
   // TalonFX config

--- a/src/main/java/frc/robot/subsystems/ArmPivot.java
+++ b/src/main/java/frc/robot/subsystems/ArmPivot.java
@@ -23,20 +23,22 @@ import java.util.function.Supplier;
 
 public class ArmPivot extends SubsystemBase {
   // Presets
-  private final double ARMPIVOT_KP = 3;
+  private final double ARMPIVOT_KP = 20;
   private final double ARMPIVOT_KI = 0;
   private final double ARMPIVOT_KD = 0;
-  private final double ARMPIVOT_KS = 0;
-  private final double ARMPIVOT_KV = 0.12;
-  private final double ARMPIVOT_KG = 0.1;
-  private final double ARMPIVOT_KA = 0.01;
-  public static final double PRESET_L1 = 0.3; // This is at position perpendicular to elevator
-  public static final double PRESET_L2_L3 = 0.38;
-  public static final double PRESET_L4 = 0.3;
-  public static final double PRESET_UP = 0.55; // Pointing Directly upwards
-  public static final double PRESET_DOWN = 0.06;
-  public static final double HARDSTOP_HIGH = 0.63;
-  public static final double HARDSTOP_LOW = 0.05;
+  private final double ARMPIVOT_KS = 0.1;
+  private final double ARMPIVOT_KV = 0.69;
+  private final double ARMPIVOT_KG = 0.18;
+  private final double ARMPIVOT_KA = 0.0;
+  public static final double PRESET_L1 = 0; // This is at position perpendicular to elevator
+  public static final double PRESET_L2_L3 = 0.125;
+  public static final double PRESET_L4 = 0.0;
+  public static final double PRESET_PRE_L4 = 1.0 / 16.0;
+  public static final double PRESET_STOWED = 0.125;
+  public static final double PRESET_UP = 0.25; // Pointing Directly upwards
+  public static final double PRESET_DOWN = -0.25;
+  public static final double HARDSTOP_HIGH = 0.32;
+  public static final double HARDSTOP_LOW = -0.26;
   public static final double POS_TOLERANCE = 0.01;
   public static final double PLACEHOLDER_CORAL_WEIGHT_KG = 0.8;
   // Constant for gear ratio (the power that one motor gives to gear)
@@ -116,7 +118,7 @@ public class ArmPivot extends SubsystemBase {
 
   // (+) is to move arm up, and (-) is down
   public Command startMovingVoltage(Supplier<Voltage> speedControl) {
-    return run(() -> motor.setVoltage(speedControl.get().in(Volts)));
+    return runEnd(() -> motor.setVoltage(speedControl.get().in(Volts)), () -> motor.stopMotor());
   }
 
   // logging
@@ -172,6 +174,5 @@ public class ArmPivot extends SubsystemBase {
         1600; // Target jerk of 1600 rps/s/s (0.1 seconds)
 
     cfg.apply(talonFXConfiguration);
-    motor.setPosition(0);
   }
 }

--- a/src/main/java/frc/robot/subsystems/ElevatorSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ElevatorSubsystem.java
@@ -12,6 +12,7 @@ import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.sysid.SysIdRoutineLog;
 import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
 import frc.robot.Hardware;
@@ -19,14 +20,16 @@ import java.util.function.DoubleConsumer;
 
 public class ElevatorSubsystem extends SubsystemBase {
   // Maximum is 38.34
-  public static final double LEVEL_FOUR_POS = 38;
+  public static final double LEVEL_FOUR_PRE_POS = 37.5;
+  public static final double LEVEL_FOUR_POS = 36.5;
   public static final double LEVEL_THREE_POS = 13;
   public static final double LEVEL_TWO_POS = 3.15;
   public static final double LEVEL_ONE_POS = 8.06;
-  public static final double STOWED = 1;
-  public static final double INTAKE = 0;
-  public static final double MANUAL = 1;
-  private static final double POS_TOLERANCE = 0.02;
+  public static final double STOWED = 2;
+  public static final double INTAKE = 0.1;
+  public static final double PRE_INTAKE = 2;
+  public static final double MANUAL = 0.1;
+  private static final double POS_TOLERANCE = 0.1;
   private final double ELEVATOR_KP = 13.804; // add feedfwds for each stage?
   private final double ELEVATOR_KI = 0;
   private final double ELEVATOR_KD = 0.079221;
@@ -229,7 +232,7 @@ public class ElevatorSubsystem extends SubsystemBase {
                 rumble.accept(0.2);
               }
             })
-        .until(() -> Math.abs(getCurrentPosition() - pos) < POS_TOLERANCE)
+        .andThen(Commands.waitUntil(() -> Math.abs(getCurrentPosition() - pos) < POS_TOLERANCE))
         .withName("setLevel" + pos);
   }
 
@@ -272,8 +275,7 @@ public class ElevatorSubsystem extends SubsystemBase {
   }
 
   /** Stop the control loop and motor output. */
-  public void stop() {
-    // m_controller.setGoal(0.0);
-    m_motor.set(0.0);
+  public Command stop() {
+    return runOnce(() -> m_motor.stopMotor()).ignoringDisable(true).withName("ElevatorStop");
   }
 }

--- a/src/main/java/frc/robot/subsystems/ElevatorSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ElevatorSubsystem.java
@@ -217,6 +217,7 @@ public class ElevatorSubsystem extends SubsystemBase {
         () -> {
           setCurrentPosition(0);
           hasBeen0ed = true;
+          rumble.accept(0);
         });
   }
 
@@ -227,7 +228,6 @@ public class ElevatorSubsystem extends SubsystemBase {
                 m_motor.setControl(m_request.withPosition(pos));
                 m_motor2.setControl(new Follower(m_motor.getDeviceID(), true));
                 targetPos = pos;
-                rumble.accept(0);
               } else {
                 rumble.accept(0.2);
               }

--- a/src/main/java/frc/robot/subsystems/ElevatorSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ElevatorSubsystem.java
@@ -29,14 +29,17 @@ public class ElevatorSubsystem extends SubsystemBase {
   public static final double INTAKE = 0;
   public static final double MANUAL = 1;
   private static final double POS_TOLERANCE = 0.02;
+  // PID
   private final double ELEVATOR_KP = 3; // add feedfwds for each stage?
   private final double ELEVATOR_KI = 0;
   private final double ELEVATOR_KD = 0;
   private final double ELEVATOR_KS = 0;
   private final double ELEVATOR_KV = 0;
   private final double ELEVATOR_KA = 0;
+
   private final double REVERSE_SOFT_LIMIT = INTAKE - 0.05;
   private final double FORWARD_SOFT_LIMIT = LEVEL_FOUR_POS + 1;
+
   private final double UP_VOLTAGE = -3;
   private final double DOWN_VOLTAGE = 3;
   private final double HOLD_VOLTAGE = 0;

--- a/src/main/java/frc/robot/subsystems/ElevatorSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ElevatorSubsystem.java
@@ -156,10 +156,33 @@ public class ElevatorSubsystem extends SubsystemBase {
     configuration.Slot0.kD = ELEVATOR_KD; // A velocity error of 1 rps results in 0.1 V output
 
     // set Motion Magic settings
-    configuration.MotionMagic.MotionMagicCruiseVelocity = 80; // Target cruise velocity of 80 rps
-    configuration.MotionMagic.MotionMagicAcceleration =
-        160; // Target acceleration of 160 rps/s (0.5 seconds)
-    configuration.MotionMagic.MotionMagicJerk = 1600; // Target jerk of 1600 rps/s/s (0.1 seconds)
+    // Bottom to full: ~40 rotations
+    // Constant jerk:
+    //   x = 1/6 j t^3
+    //   j = 6 x / t^3
+    // Considering half of the movement:
+    //   j = 6 (x/2) / (t/2)^3
+    //     = 24 x / t^3
+    // Maximum acceleration:
+    //   a = j (t/2)
+    //     = (24 x / t^3) (t/2)
+    //     = 12 x / t^2
+    // For full travel in 0.8 seconds:
+    //   j = 24 (40 rot) / (0.8 s)^3
+    //     = 1875 rot/s^3
+    //   a = 12 (40 rot) / (0.8 s)^2
+    //     = 750 rot/s^2
+    // For full travel in 0.75 seconds:
+    //   j = 24 (40 rot) / (0.75 s)^3
+    //     = (61440 / 27) rot/s^3
+    //     = 2275.56 rot/s^3
+    //   a = 12 (40 rot) / (0.75 s)^2
+    //     = (7680 / 9) rot/s^2
+    //     = 853.33 rot/s^2
+    // MotionMagic uses mechanism rotations per second*
+    configuration.MotionMagic.MotionMagicCruiseVelocity = 80;
+    configuration.MotionMagic.MotionMagicAcceleration = 750;
+    configuration.MotionMagic.MotionMagicJerk = 1875;
 
     talonFXConfigurator.apply(configuration);
   }

--- a/src/main/java/frc/robot/subsystems/ElevatorSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ElevatorSubsystem.java
@@ -18,7 +18,8 @@ import frc.robot.Hardware;
 import java.util.function.DoubleConsumer;
 
 public class ElevatorSubsystem extends SubsystemBase {
-  public static final double LEVEL_FOUR_POS = 37;
+  // Maximum is 38.34
+  public static final double LEVEL_FOUR_POS = 38;
   public static final double LEVEL_THREE_POS = 13;
   public static final double LEVEL_TWO_POS = 3.15;
   public static final double LEVEL_ONE_POS = 8.06;

--- a/src/main/java/frc/robot/subsystems/SpinnyClaw.java
+++ b/src/main/java/frc/robot/subsystems/SpinnyClaw.java
@@ -15,10 +15,8 @@ import frc.robot.Hardware;
 import java.util.function.Supplier;
 
 public class SpinnyClaw extends SubsystemBase {
-  public static final double INTAKE_SPEED =
-      4; // untested, starting with a guess direction and speed
-  public static final double EXTAKE_SPEED =
-      -4; // untested, starting with a guess direction and speed
+  public static final double INTAKE_SPEED = -4;
+  public static final double EXTAKE_SPEED = 2;
   // Remove once we implement PID speed
   public static int placeholderPIDSpeed;
 
@@ -61,14 +59,24 @@ public class SpinnyClaw extends SubsystemBase {
   }
 
   public Command intakePower() {
-    return runOnce(() -> motor.setVoltage(INTAKE_SPEED));
+    return runOnce(() -> motor.setVoltage(INTAKE_SPEED)).withName("Intake power");
   }
 
   public Command extakePower() {
-    return runOnce(() -> motor.setVoltage(EXTAKE_SPEED));
+    return runOnce(() -> motor.setVoltage(EXTAKE_SPEED)).withName("Extake power");
+  }
+
+  public Command holdIntakePower() {
+    return startEnd(() -> motor.setVoltage(INTAKE_SPEED), () -> motor.stopMotor())
+        .withName("Hold intake power");
+  }
+
+  public Command holdExtakePower() {
+    return startEnd(() -> motor.setVoltage(EXTAKE_SPEED), () -> motor.stopMotor())
+        .withName("Hold extake power");
   }
 
   public Command stop() {
-    return runOnce(() -> motor.stopMotor());
+    return runOnce(() -> motor.stopMotor()).withName("Spinny claw stop");
   }
 }

--- a/src/main/java/frc/robot/subsystems/SpinnyClaw.java
+++ b/src/main/java/frc/robot/subsystems/SpinnyClaw.java
@@ -15,6 +15,10 @@ import frc.robot.Hardware;
 import java.util.function.Supplier;
 
 public class SpinnyClaw extends SubsystemBase {
+  public static final double INTAKE_SPEED =
+      4; // untested, starting with a guess direction and speed
+  public static final double EXTAKE_SPEED =
+      -4; // untested, starting with a guess direction and speed
   // Remove once we implement PID speed
   public static int placeholderPIDSpeed;
 
@@ -35,10 +39,10 @@ public class SpinnyClaw extends SubsystemBase {
 
   // Log tabs to shuffleboard, temperature, and motor speed
   public void logTabs() {
-    Shuffleboard.getTab("claw-info")
-        .addDouble("claw_speed", () -> motor.getVelocity().getValueAsDouble());
-    Shuffleboard.getTab("claw-info")
-        .addDouble("claw_motor_temp", () -> motor.getDeviceTemp().getValueAsDouble());
+    Shuffleboard.getTab("Claw")
+        .addDouble("Claw Speed", () -> motor.getVelocity().getValueAsDouble());
+    Shuffleboard.getTab("Claw")
+        .addDouble("Claw Motor Temperature", () -> motor.getDeviceTemp().getValueAsDouble());
   }
 
   // TalonFX config
@@ -54,5 +58,17 @@ public class SpinnyClaw extends SubsystemBase {
     currentLimits.SupplyCurrentLimit = 40; // subject to change
     currentLimits.SupplyCurrentLimitEnable = true;
     cfg.apply(currentLimits);
+  }
+
+  public Command intakePower() {
+    return runOnce(() -> motor.setVoltage(INTAKE_SPEED));
+  }
+
+  public Command extakePower() {
+    return runOnce(() -> motor.setVoltage(EXTAKE_SPEED));
+  }
+
+  public Command stop() {
+    return runOnce(() -> motor.stopMotor());
   }
 }

--- a/src/main/java/frc/robot/subsystems/SuperStructure.java
+++ b/src/main/java/frc/robot/subsystems/SuperStructure.java
@@ -19,19 +19,13 @@ public class SuperStructure {
     this.armSensor = armSensor;
   }
 
-  public Command levelFourPrescore() {
-    return Commands.parallel(
-            // may need to change things if elevator/arm move at different times
-            // arm may need to move first - sequential?
-            elevator.setLevel(ElevatorSubsystem.LEVEL_FOUR_POS),
-            armPivot.moveToPosition(ArmPivot.PRESET_UP),
-            spinnyClaw.stop())
-        .andThen(armPivot.moveToPosition(ArmPivot.PRESET_PRE_L4));
-  }
-
   public Command levelFour(BooleanSupplier score) {
     return Commands.sequence(
-        levelFourPrescore(),
+        Commands.parallel(
+            elevator.setLevel(ElevatorSubsystem.LEVEL_FOUR_PRE_POS),
+            armPivot.moveToPosition(ArmPivot.PRESET_UP),
+            spinnyClaw.stop()),
+        armPivot.moveToPosition(ArmPivot.PRESET_PRE_L4),
         Commands.waitUntil(score),
         Commands.parallel(
             elevator.setLevel(ElevatorSubsystem.LEVEL_FOUR_POS),
@@ -109,11 +103,16 @@ public class SuperStructure {
 
   public Command intake() {
     return Commands.sequence(
-        Commands.parallel(
+            Commands.parallel(
+                elevator.setLevel(ElevatorSubsystem.PRE_INTAKE),
+                armPivot.moveToPosition(ArmPivot.PRESET_DOWN),
+                spinnyClaw.intakePower()),
+            // Commands.waitUntil(armSensor.inClaw()),
             elevator.setLevel(ElevatorSubsystem.INTAKE),
-            armPivot.moveToPosition(ArmPivot.PRESET_DOWN),
-            spinnyClaw.intakePower()),
-        Commands.waitUntil(armSensor.inClaw()),
-        stow());
+            Commands.waitSeconds(0.1),
+            spinnyClaw.stop(),
+            elevator.setLevel(ElevatorSubsystem.PRE_INTAKE),
+            stow())
+        .withName("Intake");
   }
 }

--- a/src/main/java/frc/robot/subsystems/SuperStructure.java
+++ b/src/main/java/frc/robot/subsystems/SuperStructure.java
@@ -21,23 +21,23 @@ public class SuperStructure {
 
   public Command levelFourPrescore() {
     return Commands.parallel(
-        // may need to change things if elevator/arm move at different times
-        // arm may need to move first - sequential?
-        elevator.setLevel(ElevatorSubsystem.LEVEL_FOUR_POS),
-        armPivot.moveToPosition(ArmPivot.PRESET_UP),
-        spinnyClaw.stop());
-  }
-
-  public Command levelFourScore() {
-    return Commands.parallel(
-        elevator.setLevel(ElevatorSubsystem.STOWED),
-        armPivot.moveToPosition(ArmPivot.PRESET_L4),
-        spinnyClaw.extakePower());
+            // may need to change things if elevator/arm move at different times
+            // arm may need to move first - sequential?
+            elevator.setLevel(ElevatorSubsystem.LEVEL_FOUR_POS),
+            armPivot.moveToPosition(ArmPivot.PRESET_UP),
+            spinnyClaw.stop())
+        .andThen(armPivot.moveToPosition(ArmPivot.PRESET_PRE_L4));
   }
 
   public Command levelFour(BooleanSupplier score) {
     return Commands.sequence(
-        levelFourPrescore(), Commands.waitUntil(score), levelFourScore(), stow());
+        levelFourPrescore(),
+        Commands.waitUntil(score),
+        Commands.parallel(
+            elevator.setLevel(ElevatorSubsystem.LEVEL_FOUR_POS),
+            armPivot.moveToPosition(ArmPivot.PRESET_L4)),
+        spinnyClaw.holdExtakePower().withTimeout(0.2),
+        stow());
   }
 
   public Command levelThreePrescore() {
@@ -75,7 +75,10 @@ public class SuperStructure {
 
   public Command levelTwo(BooleanSupplier score) {
     return Commands.sequence(
-        levelTwoPrescore(), Commands.waitUntil(score), levelTwoScore(), stow());
+        levelTwoPrescore(),
+        Commands.waitUntil(score),
+        levelTwoScore().alongWith(Commands.waitSeconds(0.2)),
+        stow());
   }
 
   public Command levelOnePrescore() {
@@ -100,7 +103,7 @@ public class SuperStructure {
   public Command stow() {
     return Commands.parallel(
         elevator.setLevel(ElevatorSubsystem.STOWED),
-        armPivot.moveToPosition(ArmPivot.PRESET_DOWN),
+        armPivot.moveToPosition(ArmPivot.PRESET_STOWED),
         spinnyClaw.stop());
   }
 

--- a/src/main/java/frc/robot/subsystems/SuperStructure.java
+++ b/src/main/java/frc/robot/subsystems/SuperStructure.java
@@ -1,0 +1,116 @@
+package frc.robot.subsystems;
+
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.Commands;
+import frc.robot.sensors.ArmSensor;
+import java.util.function.BooleanSupplier;
+
+public class SuperStructure {
+  private final ElevatorSubsystem elevator;
+  private final ArmPivot armPivot;
+  private final SpinnyClaw spinnyClaw;
+  private final ArmSensor armSensor;
+
+  public SuperStructure(
+      ElevatorSubsystem elevator, ArmPivot armPivot, SpinnyClaw spinnyClaw, ArmSensor armSensor) {
+    this.elevator = elevator;
+    this.armPivot = armPivot;
+    this.spinnyClaw = spinnyClaw;
+    this.armSensor = armSensor;
+  }
+
+  public Command levelFourPrescore() {
+    return Commands.parallel(
+        // may need to change things if elevator/arm move at different times
+        // arm may need to move first - sequential?
+        elevator.setLevel(ElevatorSubsystem.LEVEL_FOUR_POS),
+        armPivot.moveToPosition(ArmPivot.PRESET_UP),
+        spinnyClaw.stop());
+  }
+
+  public Command levelFourScore() {
+    return Commands.parallel(
+        elevator.setLevel(ElevatorSubsystem.STOWED),
+        armPivot.moveToPosition(ArmPivot.PRESET_L4),
+        spinnyClaw.extakePower());
+  }
+
+  public Command levelFour(BooleanSupplier score) {
+    return Commands.sequence(
+        levelFourPrescore(), Commands.waitUntil(score), levelFourScore(), stow());
+  }
+
+  public Command levelThreePrescore() {
+    return Commands.parallel(
+        elevator.setLevel(ElevatorSubsystem.LEVEL_THREE_POS),
+        armPivot.moveToPosition(ArmPivot.PRESET_L2_L3),
+        spinnyClaw.stop());
+  }
+
+  public Command levelThreeScore() {
+    return Commands.parallel(
+        elevator.setLevel(ElevatorSubsystem.STOWED),
+        armPivot.moveToPosition(ArmPivot.PRESET_L2_L3),
+        spinnyClaw.extakePower());
+  }
+
+  public Command levelThree(BooleanSupplier score) {
+    return Commands.sequence(
+        levelThreePrescore(), Commands.waitUntil(score), levelThreeScore(), stow());
+  }
+
+  public Command levelTwoPrescore() {
+    return Commands.parallel(
+        elevator.setLevel(ElevatorSubsystem.LEVEL_TWO_POS),
+        armPivot.moveToPosition(ArmPivot.PRESET_L2_L3),
+        spinnyClaw.stop());
+  }
+
+  public Command levelTwoScore() {
+    return Commands.parallel(
+        elevator.setLevel(ElevatorSubsystem.STOWED),
+        armPivot.moveToPosition(ArmPivot.PRESET_L2_L3),
+        spinnyClaw.extakePower());
+  }
+
+  public Command levelTwo(BooleanSupplier score) {
+    return Commands.sequence(
+        levelTwoPrescore(), Commands.waitUntil(score), levelTwoScore(), stow());
+  }
+
+  public Command levelOnePrescore() {
+    return Commands.parallel(
+        elevator.setLevel(ElevatorSubsystem.LEVEL_ONE_POS),
+        armPivot.moveToPosition(ArmPivot.PRESET_L1),
+        spinnyClaw.stop());
+  }
+
+  public Command levelOneScore() {
+    return Commands.parallel(
+        elevator.setLevel(ElevatorSubsystem.STOWED),
+        armPivot.moveToPosition(ArmPivot.PRESET_L1),
+        spinnyClaw.extakePower());
+  }
+
+  public Command levelOne(BooleanSupplier score) {
+    return Commands.sequence(
+        levelOnePrescore(), Commands.waitUntil(score), levelOneScore(), stow());
+  }
+
+  public Command stow() {
+    return Commands.parallel(
+        elevator.setLevel(ElevatorSubsystem.STOWED),
+        armPivot.moveToPosition(ArmPivot.PRESET_DOWN),
+        spinnyClaw.stop());
+  }
+
+  public Command intake() {
+    return Commands.sequence(
+        Commands.parallel(
+            elevator.setLevel(ElevatorSubsystem.INTAKE),
+            armPivot.moveToPosition(ArmPivot.PRESET_DOWN),
+            spinnyClaw.intakePower()),
+        Commands.waitUntil(armSensor.inClaw()),
+        stow());
+  }
+}


### PR DESCRIPTION
Notable happenings, and lessons (for posterity):
* SysId did not work for the arm pivot (The arm pivot is likely too light and has too short of a travel), so we ended up using https://reca.lc and some guessing adjustments to kG and kS- Don't whack everything with the same hammer
* We spent a lot of time figuring out arm pivot and spinny claw issues before realizing they needed to be inverted- Verify directions as soon as the physical setup is received
* Debugging was slowed down by having to add names to commands- Require from the beginning of build season that all commands have names
* We needed to configure the arm encoder offset (in Phoenix Tuner) so that 0 is horizontal, since that's what `GravityTypeValue.Arm_Cosine` assumes- Verify assumptions of feedforwards
* The first test of the L4 superstructure preset (done on 56208d0cf3135a24d2b478e89b72cc429d16f11f, maybe with some changes) was done with a coral on the reef, and the arm didn't let go of the coral as it went down and ended up breaking the reef branch- Verify sequence logic away from field elements and think about potential collisions
* In a subsequent test of the L4 superstructure preset, the arm pivot (still holding the coral) swung down while the elevator was retracting, leading to the coral jamming between the elevator crossbraces- Verify sequence logic without game pieces and think about potential collisions; Pick designs that avoid complicated "Keep out" portions of the state space (including the presence of game pieces)
* During testing, after reenabling the elevator went to L4 with a coral in the trough, leading to the coral hitting the bottom elevator crossbrace- Pick designs that avoid complicated "Keep out" portions of the state space (including the presence of game pieces); Ensure motor commanded positions are cleared during disable to avoid unexpected behavior
* During drive practice, we went to L4 with a coral in the trough that hadn't been transferred to the arm pivot, leading to the coral ramming into the bottom elevator crossbrace- Pick designs that avoid complicated "Keep out" portions of the state space (including the presence of game pieces); Use sensors (when attached) to prevent bad transitions between states

Fixes #28.