### PR TITLE
2/20 preset testing

### DIFF
--- a/src/main/java/frc/robot/Controls.java
+++ b/src/main/java/frc/robot/Controls.java
@@ -4,6 +4,7 @@ import static edu.wpi.first.units.Units.*;
 
 import com.ctre.phoenix6.swerve.SwerveModule.DriveRequestType;
 import com.ctre.phoenix6.swerve.SwerveRequest;
+import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.wpilibj.GenericHID.RumbleType;
 import edu.wpi.first.wpilibj2.command.Commands;
@@ -159,6 +160,7 @@ public class Controls {
     operatorController
         .a()
         .onTrue(superStructure.levelOne(driverController.rightBumper()).withName("level 1"));
+    operatorController.rightBumper().onTrue(superStructure.stow().withName("Stow"));
     driverController.a().onTrue(superStructure.intake());
     if (sensors.armSensor != null) {
       sensors.armSensor.inTrough().onTrue(superStructure.intake());
@@ -172,11 +174,19 @@ public class Controls {
     RobotModeTriggers.disabled().onTrue(s.elevatorSubsystem.stop());
     // Controls binding goes here
     operatorController
-        .leftTrigger()
-        .whileTrue(s.elevatorSubsystem.goUpPower().withName("Power up"));
+        .leftTrigger(0.1)
+        .whileTrue(
+            s.elevatorSubsystem
+                .goUpPower(
+                    () -> MathUtil.applyDeadband(operatorController.getLeftTriggerAxis(), 0.1))
+                .withName("Power up"));
     operatorController
-        .rightTrigger()
-        .whileTrue(s.elevatorSubsystem.goDownPower().withName("Power down"));
+        .rightTrigger(0.1)
+        .whileTrue(
+            s.elevatorSubsystem
+                .goDownPower(
+                    () -> MathUtil.applyDeadband(operatorController.getRightTriggerAxis(), 0.1))
+                .withName("Power down"));
     // operatorController
     //     .leftTrigger()
     //     .whileTrue(s.elevatorSubsystem.sysIdDynamic(Direction.kForward));

--- a/src/main/java/frc/robot/Controls.java
+++ b/src/main/java/frc/robot/Controls.java
@@ -17,7 +17,9 @@ import frc.robot.generated.CompTunerConstants;
 import frc.robot.subsystems.ArmPivot;
 import frc.robot.subsystems.ElevatorSubsystem;
 import frc.robot.subsystems.SuperStructure;
+import frc.robot.util.BranchHeight;
 import frc.robot.util.RobotType;
+import java.util.Map;
 
 public class Controls {
   private static final int DRIVER_CONTROLLER_PORT = 0;
@@ -36,6 +38,8 @@ public class Controls {
   private final Subsystems s;
   private final Sensors sensors;
   private final SuperStructure superStructure;
+
+  private BranchHeight branchHeight = null;
 
   // Swerve stuff
   private double MaxSpeed =
@@ -150,21 +154,37 @@ public class Controls {
     // operator start button used for climb - bound in climb bindings
     operatorController
         .y()
-        .onTrue(superStructure.levelFour(driverController.rightBumper()).withName("level 4"));
+        .onTrue(Commands.runOnce(() -> branchHeight = BranchHeight.LEVEL_FOUR).withName("level 4"));
     operatorController
         .x()
-        .onTrue(superStructure.levelThree(driverController.rightBumper()).withName("level 3"));
+        .onTrue(
+            Commands.runOnce(() -> branchHeight = BranchHeight.LEVEL_THREE).withName("level 3"));
     operatorController
         .b()
-        .onTrue(superStructure.levelTwo(driverController.rightBumper()).withName("level 2"));
+        .onTrue(Commands.runOnce(() -> branchHeight = BranchHeight.LEVEL_TWO).withName("level 2"));
     operatorController
         .a()
-        .onTrue(superStructure.levelOne(driverController.rightBumper()).withName("level 1"));
+        .onTrue(Commands.runOnce(() -> branchHeight = BranchHeight.LEVEL_ONE).withName("level 1"));
     operatorController.rightBumper().onTrue(superStructure.stow().withName("Stow"));
     driverController.a().onTrue(superStructure.intake());
     if (sensors.armSensor != null) {
       sensors.armSensor.inTrough().onTrue(superStructure.intake());
     }
+    driverController
+        .leftBumper()
+        .onTrue(
+            Commands.select(
+                    Map.of(
+                        BranchHeight.LEVEL_FOUR,
+                        superStructure.levelFour(driverController.rightBumper()),
+                        BranchHeight.LEVEL_THREE,
+                        superStructure.levelThree(driverController.rightBumper()),
+                        BranchHeight.LEVEL_TWO,
+                        superStructure.levelTwo(driverController.rightBumper()),
+                        BranchHeight.LEVEL_ONE,
+                        superStructure.levelOne(driverController.rightBumper())),
+                    () -> branchHeight)
+                .withName("go to target branch height"));
   }
 
   private void configureElevatorBindings() {

--- a/src/main/java/frc/robot/Controls.java
+++ b/src/main/java/frc/robot/Controls.java
@@ -46,8 +46,8 @@ public class Controls {
       RobotType.getCurrent() == RobotType.BONK
           ? BonkTunerConstants.kSpeedAt12Volts.in(MetersPerSecond)
           : CompTunerConstants.kSpeedAt12Volts.in(MetersPerSecond);
-  private final double MAX_ACCELERATION = 1.0;
-  private final double MAX_ROTATION_ACCELERATION = 1.0;
+  private final double MAX_ACCELERATION = 50;
+  private final double MAX_ROTATION_ACCELERATION = 50;
   // kSpeedAt12Volts desired top speed
   private double MaxAngularRate =
       RotationsPerSecond.of(0.75)
@@ -107,15 +107,22 @@ public class Controls {
                   double dt = 0.02;
                   // Vx Vy and Omega are really accelerations and not velocities.
                   ChassisSpeeds acceleration = diff.div(dt);
-                  double translationAccelMagnitude =
-                      Math.hypot(acceleration.vxMetersPerSecond, acceleration.vyMetersPerSecond);
-                  ChassisSpeeds translationLimit =
-                      acceleration.times(Math.min(1, MAX_ACCELERATION / translationAccelMagnitude));
-                  ChassisSpeeds rotationLimit =
-                      translationLimit.times(
-                          Math.min(
-                              1,
-                              MAX_ROTATION_ACCELERATION / translationLimit.omegaRadiansPerSecond));
+                  // double translationAccelMagnitude =
+                  //     Math.hypot(acceleration.vxMetersPerSecond, acceleration.vyMetersPerSecond);
+                  // ChassisSpeeds translationLimit =
+                  //     acceleration.times(
+                  //         Math.min(1, Math.abs(MAX_ACCELERATION / translationAccelMagnitude)));
+                  // ChassisSpeeds rotationLimit =
+                  //     translationLimit.times(
+                  //         Math.min(
+                  //             1,
+                  //             Math.abs(
+                  //                 MAX_ROTATION_ACCELERATION
+                  //                     / translationLimit.omegaRadiansPerSecond)));
+                  // This *should* be rotationLimit, but the acceleration limiting causes the
+                  // commanded speed to fall into the deadband. The proper fix is to do the deadband
+                  // first, which relies on us doing the deadband ourselves, which is being
+                  // difficult.
                   ChassisSpeeds newSpeeds = speed.plus(acceleration.times(dt));
 
                   return drive

--- a/src/main/java/frc/robot/Controls.java
+++ b/src/main/java/frc/robot/Controls.java
@@ -172,6 +172,7 @@ public class Controls {
     }
     driverController
         .leftBumper()
+        .onTrue(s.elevatorSubsystem.runOnce(() -> {}).withName("elevator interruptor"))
         .onTrue(
             Commands.select(
                     Map.of(

--- a/src/main/java/frc/robot/subsystems/ArmPivot.java
+++ b/src/main/java/frc/robot/subsystems/ArmPivot.java
@@ -11,6 +11,7 @@ import com.ctre.phoenix6.signals.FeedbackSensorSourceValue;
 import com.ctre.phoenix6.signals.GravityTypeValue;
 import com.ctre.phoenix6.signals.InvertedValue;
 import com.ctre.phoenix6.signals.NeutralModeValue;
+import edu.wpi.first.math.util.Units;
 import edu.wpi.first.units.measure.Voltage;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj2.command.Command;
@@ -31,7 +32,7 @@ public class ArmPivot extends SubsystemBase {
   private final double ARMPIVOT_KG = 0.18;
   private final double ARMPIVOT_KA = 0.0;
   public static final double PRESET_L1 = 0; // This is at position perpendicular to elevator
-  public static final double PRESET_L2_L3 = 0.125;
+  public static final double PRESET_L2_L3 = Units.degreesToRotations(55);
   public static final double PRESET_L4 = 0.0;
   public static final double PRESET_PRE_L4 = 1.0 / 16.0;
   public static final double PRESET_STOWED = 0.125;

--- a/src/main/java/frc/robot/subsystems/ArmPivot.java
+++ b/src/main/java/frc/robot/subsystems/ArmPivot.java
@@ -95,7 +95,7 @@ public class ArmPivot extends SubsystemBase {
     return targetPos;
   }
 
-  private double getCurrentMotorPosition() {
+  private double getCurrentPosition() {
     var curPos = motor.getPosition();
     return curPos.getValueAsDouble();
   }
@@ -113,8 +113,7 @@ public class ArmPivot extends SubsystemBase {
     // double
     return setTargetPosition(position)
         .andThen(
-            Commands.waitUntil(
-                () -> Math.abs(getCurrentMotorPosition() - position) < POS_TOLERANCE));
+            Commands.waitUntil(() -> Math.abs(getCurrentPosition() - position) < POS_TOLERANCE));
   }
 
   // (+) is to move arm up, and (-) is down
@@ -128,9 +127,10 @@ public class ArmPivot extends SubsystemBase {
         .addDouble("Pivot Speed", () -> motor.getVelocity().getValueAsDouble());
     Shuffleboard.getTab("Arm Pivot")
         .addDouble("Pivot Motor Temperature", () -> motor.getDeviceTemp().getValueAsDouble());
-    Shuffleboard.getTab("Arm Pivot")
-        .addDouble("Pivot Motor Position", () -> getCurrentMotorPosition());
+    Shuffleboard.getTab("Arm Pivot").addDouble("Pivot Position", () -> getCurrentPosition());
     Shuffleboard.getTab("Arm Pivot").addDouble("Pivot Target Pos", () -> getTargetPosition());
+    Shuffleboard.getTab("Arm Pivot")
+        .addDouble("Pivot Motor rotor Pos", () -> motor.getRotorPosition().getValueAsDouble());
   }
 
   // TalonFX config

--- a/src/main/java/frc/robot/subsystems/ElevatorSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ElevatorSubsystem.java
@@ -17,13 +17,16 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
 import frc.robot.Hardware;
 import java.util.function.DoubleConsumer;
+import java.util.function.DoubleSupplier;
 
 public class ElevatorSubsystem extends SubsystemBase {
   // Maximum is 38.34
   public static final double LEVEL_FOUR_PRE_POS = 37.5;
   public static final double LEVEL_FOUR_POS = 36.5;
-  public static final double LEVEL_THREE_POS = 13;
-  public static final double LEVEL_TWO_POS = 3.15;
+  public static final double LEVEL_THREE_PRE_POS = 16.8;
+  public static final double LEVEL_THREE_POS = 14;
+  public static final double LEVEL_TWO_PRE_POS = 3.15;
+  public static final double LEVEL_TWO_POS = 3;
   public static final double LEVEL_ONE_POS = 8.06;
   public static final double STOWED = 2;
   public static final double INTAKE = 0.1;
@@ -244,11 +247,11 @@ public class ElevatorSubsystem extends SubsystemBase {
     return defer(() -> setLevel(getCurrentPosition() - MANUAL));
   }
 
-  public Command goUpPower() {
-    return startEnd(
+  public Command goUpPower(DoubleSupplier scale) {
+    return runEnd(
             () -> {
-              m_motor.setVoltage(UP_VOLTAGE);
-              m_motor2.setVoltage(-UP_VOLTAGE);
+              m_motor.setVoltage(scale.getAsDouble() * UP_VOLTAGE);
+              m_motor2.setVoltage(scale.getAsDouble() * -UP_VOLTAGE);
             },
             () -> {
               m_motor.stopMotor();
@@ -259,11 +262,11 @@ public class ElevatorSubsystem extends SubsystemBase {
         .withName("Elevator up power");
   }
 
-  public Command goDownPower() {
+  public Command goDownPower(DoubleSupplier scale) {
     return startEnd(
             () -> {
-              m_motor.setVoltage(DOWN_VOLTAGE);
-              m_motor2.setVoltage(-DOWN_VOLTAGE);
+              m_motor.setVoltage(scale.getAsDouble() * DOWN_VOLTAGE);
+              m_motor2.setVoltage(scale.getAsDouble() * -DOWN_VOLTAGE);
             },
             () -> {
               m_motor.stopMotor();

--- a/src/main/java/frc/robot/subsystems/ElevatorSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ElevatorSubsystem.java
@@ -25,8 +25,8 @@ public class ElevatorSubsystem extends SubsystemBase {
   public static final double LEVEL_FOUR_POS = 36.5;
   public static final double LEVEL_THREE_PRE_POS = 16.8;
   public static final double LEVEL_THREE_POS = 14;
-  public static final double LEVEL_TWO_PRE_POS = 3.15;
-  public static final double LEVEL_TWO_POS = 3;
+  public static final double LEVEL_TWO_PRE_POS = 4.8;
+  public static final double LEVEL_TWO_POS = 4.4;
   public static final double LEVEL_ONE_POS = 8.06;
   public static final double STOWED = 2;
   public static final double INTAKE = 0.1;

--- a/src/main/java/frc/robot/subsystems/SuperStructure.java
+++ b/src/main/java/frc/robot/subsystems/SuperStructure.java
@@ -34,44 +34,29 @@ public class SuperStructure {
         stow());
   }
 
-  public Command levelThreePrescore() {
-    return Commands.parallel(
-        elevator.setLevel(ElevatorSubsystem.LEVEL_THREE_POS),
-        armPivot.moveToPosition(ArmPivot.PRESET_L2_L3),
-        spinnyClaw.stop());
-  }
-
-  public Command levelThreeScore() {
-    return Commands.parallel(
-        elevator.setLevel(ElevatorSubsystem.STOWED),
-        armPivot.moveToPosition(ArmPivot.PRESET_L2_L3),
-        spinnyClaw.extakePower());
-  }
-
   public Command levelThree(BooleanSupplier score) {
     return Commands.sequence(
-        levelThreePrescore(), Commands.waitUntil(score), levelThreeScore(), stow());
-  }
-
-  public Command levelTwoPrescore() {
-    return Commands.parallel(
-        elevator.setLevel(ElevatorSubsystem.LEVEL_TWO_POS),
+        Commands.parallel(
+            elevator.setLevel(ElevatorSubsystem.LEVEL_THREE_PRE_POS),
+            armPivot.moveToPosition(ArmPivot.PRESET_UP),
+            spinnyClaw.stop()),
         armPivot.moveToPosition(ArmPivot.PRESET_L2_L3),
-        spinnyClaw.stop());
-  }
-
-  public Command levelTwoScore() {
-    return Commands.parallel(
-        elevator.setLevel(ElevatorSubsystem.STOWED),
-        armPivot.moveToPosition(ArmPivot.PRESET_L2_L3),
-        spinnyClaw.extakePower());
+        Commands.waitUntil(score),
+        elevator.setLevel(ElevatorSubsystem.LEVEL_THREE_POS),
+        spinnyClaw.holdExtakePower().withTimeout(0.15),
+        stow());
   }
 
   public Command levelTwo(BooleanSupplier score) {
     return Commands.sequence(
-        levelTwoPrescore(),
+        Commands.parallel(
+            elevator.setLevel(ElevatorSubsystem.LEVEL_TWO_PRE_POS),
+            armPivot.moveToPosition(ArmPivot.PRESET_UP),
+            spinnyClaw.stop()),
+        armPivot.moveToPosition(ArmPivot.PRESET_L2_L3),
         Commands.waitUntil(score),
-        levelTwoScore().alongWith(Commands.waitSeconds(0.2)),
+        elevator.setLevel(ElevatorSubsystem.LEVEL_TWO_POS),
+        spinnyClaw.holdExtakePower().withTimeout(0.15),
         stow());
   }
 

--- a/src/main/java/frc/robot/util/BranchHeight.java
+++ b/src/main/java/frc/robot/util/BranchHeight.java
@@ -1,0 +1,8 @@
+package frc.robot.util;
+
+public enum BranchHeight {
+  LEVEL_ONE,
+  LEVEL_TWO,
+  LEVEL_THREE,
+  LEVEL_FOUR;
+}


### PR DESCRIPTION
Implement operator queueing/mode selection controls (Operator selects next level, driver tells robot when to move to that level)
Makes the operator manual elevator up and down controls continuous instead of discrete on/off
Fixes motor position terminology in arm pivot
Fixes L2 and L3 presets
Mostly fixes acceleration limits

Closes #32 (because this contains the same contents and a fix for a bug).

About the acceleration limits- The old code was incorrect (it would apply the pre-limit acceleration and it wouldn't handle negative rotation speeds correctly). However, after fixing it, we discovered that applying the deadband limits after the acceleration limits causes trouble (since the acceleration should map certain values to within the deadband that should not be set to 0). The fix is to apply the deadbands before the acceleration limit, but we can't do that without implementing deadband ourselves, which was proving difficult. So far we haven't had issues with tipping (even with elevator up), so both features are on low priority for the time being.

Side note about the operator queueing/mode selection controls- This presents a use case where pressing a button again should cause the command to be rescheduled. However, when a command is scheduled, the scheduler will skip it if the command is currently running. To get around this, we use the (unspecified) fact that bindings are always checked in the order that they are made so that when the trigger is pressed, first we schedule a different command with overlapping requirements to cancel the superstructure command and then schedule the actual superstructure command to start it again.
In hindsight, we could avoid relying on the unspecified definition of the binding execution order by using `interruptor.asProxy().andThen(actualCommand.asProxy())` (assuming `interruptor` finishes instantly) or `new ScheduleCommand(interruptor).andThen(new ScheduleCommand(actualCommand))` (straying from strict adherence to command factories and using a rarely used command). However, that hasn't been tested (and notably, it would add one command scheduler poll of delay).