### PR TITLE
Fixes for various issues

### DIFF
--- a/src/main/java/frc/robot/Controls.java
+++ b/src/main/java/frc/robot/Controls.java
@@ -669,7 +669,7 @@ public class Controls {
                   .blink(120, 0, 0, "Red - Elevator Not Zeroed")
                   .ignoringDisable(true));
       subZeroPosition.whileTrue(
-          Commands.waitSeconds(0.2)
+          Commands.waitSeconds(0.5)
               .andThen(
                   s.elevatorLEDSubsystem
                       .blink(120, 0, 0, "Red - Elevator Position Error")

--- a/src/main/java/frc/robot/Controls.java
+++ b/src/main/java/frc/robot/Controls.java
@@ -648,6 +648,7 @@ public class Controls {
 
     if (s.elevatorSubsystem != null) {
       Trigger hasBeenZeroed = new Trigger(s.elevatorSubsystem::getHasBeenZeroed);
+      Trigger subZeroPosition = new Trigger(s.elevatorSubsystem::getPositionSubZero);
       Commands.waitSeconds(1)
           .andThen(
               s.elevatorLEDSubsystem
@@ -667,6 +668,13 @@ public class Controls {
               s.elevatorLEDSubsystem
                   .blink(120, 0, 0, "Red - Elevator Not Zeroed")
                   .ignoringDisable(true));
+      subZeroPosition.whileTrue(
+          Commands.waitSeconds(0.2)
+              .andThen(
+                  s.elevatorLEDSubsystem
+                      .blink(120, 0, 0, "Red - Elevator Position Error")
+                      .ignoringDisable(true)
+                      .withName("Red - Elevator Position Error")));
     }
     RobotModeTriggers.autonomous()
         .whileTrue(s.elevatorLEDSubsystem.animate(LEDPattern.rainbow(255, 255), "Auto Rainbow"));

--- a/src/main/java/frc/robot/subsystems/ElevatorSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ElevatorSubsystem.java
@@ -234,7 +234,7 @@ public class ElevatorSubsystem extends SubsystemBase {
   }
 
   public boolean getPositionSubZero() {
-    if (curPos < -0.1) {
+    if (curPos < -0.1 && hasBeenZeroed) {
       return true;
     }
     return false;

--- a/src/main/java/frc/robot/subsystems/ElevatorSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ElevatorSubsystem.java
@@ -233,6 +233,13 @@ public class ElevatorSubsystem extends SubsystemBase {
     return hasBeenZeroed;
   }
 
+  public boolean getPositionSubZero() {
+    if (curPos < -0.1) {
+      return true;
+    }
+    return false;
+  }
+
   private double getTargetPosition() {
     return targetPos;
   }

--- a/src/main/java/frc/robot/subsystems/auto/AutoLogic.java
+++ b/src/main/java/frc/robot/subsystems/auto/AutoLogic.java
@@ -34,12 +34,6 @@ public class AutoLogic {
   public static final Subsystems s = r.subsystems;
   public static final Controls controls = r.controls;
 
-  public static final double FEEDER_DELAY = 0.4;
-
-  // rpm to rev up launcher before launching
-  public static final double REV_RPM = 2500;
-  public static final double STAGE_ANGLE = 262;
-
   public static enum StartPosition {
     FAR_LEFT_CAGE(
         "Far Left Cage", new Pose2d(7.187, 7.277, new Rotation2d(Units.degreesToRadians(-90)))),


### PR DESCRIPTION
Current fixes:

Added red LED flashing when the elevator is giving incorrect position readings while Zero'd, should help find faulty Zero's as they happen. (resolves #88 )