### PR TITLE
Gains tuning utility class

### DIFF
--- a/src/main/java/frc/robot/subsystems/ArmPivot.java
+++ b/src/main/java/frc/robot/subsystems/ArmPivot.java
@@ -4,6 +4,7 @@ package frc.robot.subsystems;
 import static edu.wpi.first.units.Units.Seconds;
 import static edu.wpi.first.units.Units.Volts;
 
+import com.ctre.phoenix6.configs.Slot0Configs;
 import com.ctre.phoenix6.configs.TalonFXConfiguration;
 import com.ctre.phoenix6.configs.TalonFXConfigurator;
 import com.ctre.phoenix6.controls.MotionMagicVoltage;
@@ -28,6 +29,7 @@ import edu.wpi.first.wpilibj2.command.button.Trigger;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine.Direction;
 import frc.robot.Hardware;
+import frc.robot.util.GainsTuningEntry;
 import java.util.function.Supplier;
 
 public class ArmPivot extends SubsystemBase {
@@ -74,6 +76,18 @@ public class ArmPivot extends SubsystemBase {
 
   // TalonFX
   private final TalonFX motor;
+
+  // Testing tuning entry :P
+  private final GainsTuningEntry PIDtuner =
+      new GainsTuningEntry(
+          "ArmPivot",
+          ARMPIVOT_KP,
+          ARMPIVOT_KI,
+          ARMPIVOT_KD,
+          ARMPIVOT_KA,
+          ARMPIVOT_KV,
+          ARMPIVOT_KS,
+          ARMPIVOT_KG);
 
   // alerts if motor is not connected.
   private final Alert NotConnectedError =
@@ -227,6 +241,16 @@ public class ArmPivot extends SubsystemBase {
   public void periodic() {
     // Error that ensures the motor is connected
     NotConnectedError.set(notConnectedDebouncer.calculate(!motor.getMotorVoltage().hasUpdated()));
+
+    Slot0Configs pidTunerConfigs = new Slot0Configs();
+    pidTunerConfigs.kP = PIDtuner.getP();
+    pidTunerConfigs.kI = PIDtuner.getI();
+    pidTunerConfigs.kD = PIDtuner.getD();
+    pidTunerConfigs.kS = PIDtuner.getS();
+    pidTunerConfigs.kV = PIDtuner.getV();
+    pidTunerConfigs.kA = PIDtuner.getA();
+    pidTunerConfigs.kG = ARMPIVOT_KG;
+    motor.getConfigurator().apply(pidTunerConfigs);
   }
 }
 //  -Samuel "Big North" Mallick

--- a/src/main/java/frc/robot/subsystems/ArmPivot.java
+++ b/src/main/java/frc/robot/subsystems/ArmPivot.java
@@ -34,13 +34,13 @@ import java.util.function.Supplier;
 
 public class ArmPivot extends SubsystemBase {
   // Presets
-  private final double ARMPIVOT_KP = 38.5; // previously 50
-  private final double ARMPIVOT_KI = 0;
-  private final double ARMPIVOT_KD = 0;
-  private final double ARMPIVOT_KS = 0.1;
-  private final double ARMPIVOT_KV = 0.69;
-  private final double ARMPIVOT_KG = 0.18;
-  private final double ARMPIVOT_KA = 0.0;
+  private double armPivot_kP = 38.5; // previously 50
+  private double armPivot_kI = 0;
+  private double armPivot_kD = 0;
+  private double armPivot_kS = 0.1;
+  private double armPivot_kV = 0.69;
+  private double armPivot_kG = 0.18;
+  private double armPivot_kA = 0.0;
   // Preset positions for Arm with Coral
   public static final double CORAL_PRESET_L1 = 0;
   public static final double CORAL_PRESET_L2 = 0.13;
@@ -78,17 +78,16 @@ public class ArmPivot extends SubsystemBase {
   private final TalonFX motor;
 
   // Testing tuning entry :P
-  private final boolean TUNING_ENABLED = false;
   private final GainsTuningEntry PIDtuner =
       new GainsTuningEntry(
           "ArmPivot",
-          ARMPIVOT_KP,
-          ARMPIVOT_KI,
-          ARMPIVOT_KD,
-          ARMPIVOT_KA,
-          ARMPIVOT_KV,
-          ARMPIVOT_KS,
-          ARMPIVOT_KG);
+          armPivot_kP,
+          armPivot_kI,
+          armPivot_kD,
+          armPivot_kA,
+          armPivot_kV,
+          armPivot_kS,
+          armPivot_kG);
 
   // alerts if motor is not connected.
   private final Alert NotConnectedError =
@@ -217,13 +216,13 @@ public class ArmPivot extends SubsystemBase {
 
     // PID
     // set slot 0 gains
-    talonFXConfiguration.Slot0.kS = ARMPIVOT_KS;
-    talonFXConfiguration.Slot0.kV = ARMPIVOT_KV;
-    talonFXConfiguration.Slot0.kA = ARMPIVOT_KA;
-    talonFXConfiguration.Slot0.kP = ARMPIVOT_KP;
-    talonFXConfiguration.Slot0.kI = ARMPIVOT_KI;
-    talonFXConfiguration.Slot0.kD = ARMPIVOT_KD;
-    talonFXConfiguration.Slot0.kG = ARMPIVOT_KG;
+    talonFXConfiguration.Slot0.kS = armPivot_kS;
+    talonFXConfiguration.Slot0.kV = armPivot_kV;
+    talonFXConfiguration.Slot0.kA = armPivot_kA;
+    talonFXConfiguration.Slot0.kP = armPivot_kP;
+    talonFXConfiguration.Slot0.kI = armPivot_kI;
+    talonFXConfiguration.Slot0.kD = armPivot_kD;
+    talonFXConfiguration.Slot0.kG = armPivot_kG;
     talonFXConfiguration.Slot0.GravityType = GravityTypeValue.Arm_Cosine;
 
     // set Motion Magic settings in rps not mechanism units
@@ -242,15 +241,35 @@ public class ArmPivot extends SubsystemBase {
   public void periodic() {
     // Error that ensures the motor is connected
     NotConnectedError.set(notConnectedDebouncer.calculate(!motor.getMotorVoltage().hasUpdated()));
-    if (TUNING_ENABLED) {
+
+    // checking if any of the PID gains have changed in gains tuner
+    if (PIDtuner.anyGainsChanged(
+        armPivot_kP,
+        armPivot_kI,
+        armPivot_kD,
+        armPivot_kA,
+        armPivot_kV,
+        armPivot_kS,
+        armPivot_kG)) {
+      armPivot_kP = PIDtuner.getP();
+      armPivot_kI = PIDtuner.getI();
+      armPivot_kD = PIDtuner.getD();
+      armPivot_kS = PIDtuner.getS();
+      armPivot_kV = PIDtuner.getV();
+      armPivot_kA = PIDtuner.getA();
+      armPivot_kG = PIDtuner.getG();
+
+      // creating a new Slot0Configs object to apply the new gains
       Slot0Configs pidTunerConfigs = new Slot0Configs();
-      pidTunerConfigs.kP = PIDtuner.getP();
-      pidTunerConfigs.kI = PIDtuner.getI();
-      pidTunerConfigs.kD = PIDtuner.getD();
-      pidTunerConfigs.kS = PIDtuner.getS();
-      pidTunerConfigs.kV = PIDtuner.getV();
-      pidTunerConfigs.kA = PIDtuner.getA();
-      pidTunerConfigs.kG = PIDtuner.getG();
+      pidTunerConfigs.kP = armPivot_kP;
+      pidTunerConfigs.kI = armPivot_kI;
+      pidTunerConfigs.kD = armPivot_kD;
+      pidTunerConfigs.kS = armPivot_kS;
+      pidTunerConfigs.kV = armPivot_kV;
+      pidTunerConfigs.kA = armPivot_kA;
+      pidTunerConfigs.kG = armPivot_kG;
+
+      // applying the new gains to the motor
       motor.getConfigurator().apply(pidTunerConfigs);
     }
   }

--- a/src/main/java/frc/robot/subsystems/ArmPivot.java
+++ b/src/main/java/frc/robot/subsystems/ArmPivot.java
@@ -78,6 +78,7 @@ public class ArmPivot extends SubsystemBase {
   private final TalonFX motor;
 
   // Testing tuning entry :P
+  private final boolean TUNING_ENABLED = false;
   private final GainsTuningEntry PIDtuner =
       new GainsTuningEntry(
           "ArmPivot",
@@ -241,16 +242,16 @@ public class ArmPivot extends SubsystemBase {
   public void periodic() {
     // Error that ensures the motor is connected
     NotConnectedError.set(notConnectedDebouncer.calculate(!motor.getMotorVoltage().hasUpdated()));
-
-    Slot0Configs pidTunerConfigs = new Slot0Configs();
-    pidTunerConfigs.kP = PIDtuner.getP();
-    pidTunerConfigs.kI = PIDtuner.getI();
-    pidTunerConfigs.kD = PIDtuner.getD();
-    pidTunerConfigs.kS = PIDtuner.getS();
-    pidTunerConfigs.kV = PIDtuner.getV();
-    pidTunerConfigs.kA = PIDtuner.getA();
-    pidTunerConfigs.kG = ARMPIVOT_KG;
-    motor.getConfigurator().apply(pidTunerConfigs);
+    if (TUNING_ENABLED){
+      Slot0Configs pidTunerConfigs = new Slot0Configs();
+      pidTunerConfigs.kP = PIDtuner.getP();
+      pidTunerConfigs.kI = PIDtuner.getI();
+      pidTunerConfigs.kD = PIDtuner.getD();
+      pidTunerConfigs.kS = PIDtuner.getS();
+      pidTunerConfigs.kV = PIDtuner.getV();
+      pidTunerConfigs.kA = PIDtuner.getA();
+      pidTunerConfigs.kG = ARMPIVOT_KG;
+      motor.getConfigurator().apply(pidTunerConfigs);}
   }
 }
 //  -Samuel "Big North" Mallick

--- a/src/main/java/frc/robot/subsystems/ArmPivot.java
+++ b/src/main/java/frc/robot/subsystems/ArmPivot.java
@@ -249,7 +249,7 @@ public class ArmPivot extends SubsystemBase {
     pidTunerConfigs.kS = PIDtuner.getS();
     pidTunerConfigs.kV = PIDtuner.getV();
     pidTunerConfigs.kA = PIDtuner.getA();
-    pidTunerConfigs.kG = ARMPIVOT_KG;
+    pidTunerConfigs.kG = PIDtuner.getG();
     motor.getConfigurator().apply(pidTunerConfigs);
   }
 }

--- a/src/main/java/frc/robot/subsystems/ArmPivot.java
+++ b/src/main/java/frc/robot/subsystems/ArmPivot.java
@@ -242,7 +242,7 @@ public class ArmPivot extends SubsystemBase {
   public void periodic() {
     // Error that ensures the motor is connected
     NotConnectedError.set(notConnectedDebouncer.calculate(!motor.getMotorVoltage().hasUpdated()));
-    if (TUNING_ENABLED){
+    if (TUNING_ENABLED) {
       Slot0Configs pidTunerConfigs = new Slot0Configs();
       pidTunerConfigs.kP = PIDtuner.getP();
       pidTunerConfigs.kI = PIDtuner.getI();
@@ -251,7 +251,8 @@ public class ArmPivot extends SubsystemBase {
       pidTunerConfigs.kV = PIDtuner.getV();
       pidTunerConfigs.kA = PIDtuner.getA();
       pidTunerConfigs.kG = PIDtuner.getG();
-      motor.getConfigurator().apply(pidTunerConfigs);}
+      motor.getConfigurator().apply(pidTunerConfigs);
+    }
   }
 }
 //  -Samuel "Big North" Mallick

--- a/src/main/java/frc/robot/subsystems/ArmPivot.java
+++ b/src/main/java/frc/robot/subsystems/ArmPivot.java
@@ -77,7 +77,7 @@ public class ArmPivot extends SubsystemBase {
   // TalonFX
   private final TalonFX motor;
 
-  // Testing tuning entry :P
+  // Testing tuning entry for PID gains
   private final GainsTuningEntry PIDtuner =
       new GainsTuningEntry(
           "ArmPivot",

--- a/src/main/java/frc/robot/util/GainsTuningEntry.java
+++ b/src/main/java/frc/robot/util/GainsTuningEntry.java
@@ -16,7 +16,7 @@ public class GainsTuningEntry {
   private NetworkTableEntry kSEntry;
   private NetworkTableEntry kGEntry;
 
-  /* Base PID Feedback entires. Excludes kA, kV, kS, and kG
+  /** Base PID Feedback entires. Excludes kA, kV, kS, and kG
    *
    */
   public GainsTuningEntry(String subsystemName, double kp, double ki, double kd) {
@@ -34,7 +34,7 @@ public class GainsTuningEntry {
     kDEntry.setDouble(kd);
   }
 
-  /* With ALL Feedback + Feedforward entries, INCLUDING kA
+  /** With ALL Feedback + Feedforward entries, INCLUDING kA
    *
    */
   public GainsTuningEntry(
@@ -57,7 +57,7 @@ public class GainsTuningEntry {
     kGEntry.setDouble(kg);
   }
 
-  /* With Feedback + Feedforward entries, except kA
+  /** With Feedback + Feedforward entries, except kA
    *
    */
   public GainsTuningEntry(
@@ -75,58 +75,56 @@ public class GainsTuningEntry {
     return kSubsystemName;
   }
 
-  // Get proportional gain (P)
+  /** Get proportional gain (P)
+   * 
+   */
   public double getP() {
     return kPEntry.getDouble(0);
   }
 
-  // Get integral gain (I)
+    /** Get integral gain (I)
+     * 
+     */
   public double getI() {
     return kIEntry.getDouble(0);
   }
 
-  // Get derivative gain (D)
+    /** Get derivative gain (D)
+     * 
+     */
   public double getD() {
     return kDEntry.getDouble(0);
   }
 
-  // Get acceleration gain (A)
+    /** Get acceleration gain (A)
+     * 
+     */
   public double getA() {
-    if (kAEntry == null) {
-      return 0;
-    } else {
-      return kAEntry.getDouble(0);
-    }
+    return kAEntry != null ? kAEntry.getDouble(0) : 0;
   }
 
-  // Get velocity gain (V)
+    /** Get velocity gain (V)
+     * 
+     */
   public double getV() {
-    if (kVEntry == null) {
-      return 0;
-    } else {
-      return kVEntry.getDouble(0);
-    }
+    return kVEntry != null ? kVEntry.getDouble(0) : 0;
   }
 
-  // Get static gain (S)
+    /** Get static gain (S)
+     * 
+     */
   public double getS() {
-    if (kSEntry == null) {
-      return 0;
-    } else {
-      return kSEntry.getDouble(0);
-    }
+    return kSEntry != null ? kSEntry.getDouble(0) : 0;
   }
 
-  // Get gravity gain (G)
+    /** Get gravity gain (G)
+     * 
+     */
   public double getG() {
-    if (kGEntry == null) {
-      return 0;
-    } else {
-      return kGEntry.getDouble(0);
-    }
+    return kGEntry != null ? kGEntry.getDouble(0) : 0;
   }
 
-  /* Check if any gains have changed using the current values from the subsystem.
+  /** Check if any gains have changed using the current values from the subsystem.
    * Compares all gains: P, I, D, A, V, S, G
    */
   public boolean anyGainsChanged(
@@ -138,16 +136,11 @@ public class GainsTuningEntry {
       double currentS,
       double currentG) {
 
-    return (currentP != getP()
-        || currentI != getI()
-        || currentD != getD()
-        || currentA != getA()
-        || currentV != getV()
-        || currentS != getS()
-        || currentG != getG());
+    return (pidffGainsChanged(currentP, currentI, currentD, currentV, currentS, currentG)
+        || currentA != getA());
   }
 
-  /* Check if any gains have changed using the current values from the subsystem.
+  /** Check if any gains have changed using the current values from the subsystem.
    * Compares P, I, D, V, S, G
    */
   public boolean pidffGainsChanged(
@@ -158,15 +151,13 @@ public class GainsTuningEntry {
       double currentS,
       double currentG) {
 
-    return (currentP != getP()
-        || currentI != getI()
-        || currentD != getD()
+    return (pidGainsChanged(currentP, currentI, currentD)
         || currentV != getV()
         || currentS != getS()
         || currentG != getG());
   }
 
-  /* Check if any gains have changed using the current values from the subsystem.
+  /** Check if any gains have changed using the current values from the subsystem.
    * Compares P, I, D only
    */
   public boolean pidGainsChanged(double currentP, double currentI, double currentD) {

--- a/src/main/java/frc/robot/util/GainsTuningEntry.java
+++ b/src/main/java/frc/robot/util/GainsTuningEntry.java
@@ -16,9 +16,7 @@ public class GainsTuningEntry {
   private NetworkTableEntry kSEntry;
   private NetworkTableEntry kGEntry;
 
-  /** Base PID Feedback entires. Excludes kA, kV, kS, and kG
-   *
-   */
+  /** Base PID Feedback entires. Excludes kA, kV, kS, and kG */
   public GainsTuningEntry(String subsystemName, double kp, double ki, double kd) {
     table = NetworkTableInstance.getDefault().getTable("Gains/" + subsystemName);
     this.kSubsystemName = subsystemName;
@@ -34,9 +32,7 @@ public class GainsTuningEntry {
     kDEntry.setDouble(kd);
   }
 
-  /** With ALL Feedback + Feedforward entries, INCLUDING kA
-   *
-   */
+  /** With ALL Feedback + Feedforward entries, INCLUDING kA */
   public GainsTuningEntry(
       String subsystemName,
       double kp,
@@ -57,9 +53,7 @@ public class GainsTuningEntry {
     kGEntry.setDouble(kg);
   }
 
-  /** With Feedback + Feedforward entries, except kA
-   *
-   */
+  /** With Feedback + Feedforward entries, except kA */
   public GainsTuningEntry(
       String subsystemName, double kp, double ki, double kd, double kv, double ks, double kg) {
     this(subsystemName, kp, ki, kd);
@@ -75,57 +69,44 @@ public class GainsTuningEntry {
     return kSubsystemName;
   }
 
-  /** Get proportional gain (P)
-   * 
-   */
+  /** Get proportional gain (P) */
   public double getP() {
     return kPEntry.getDouble(0);
   }
 
-    /** Get integral gain (I)
-     * 
-     */
+  /** Get integral gain (I) */
   public double getI() {
     return kIEntry.getDouble(0);
   }
 
-    /** Get derivative gain (D)
-     * 
-     */
+  /** Get derivative gain (D) */
   public double getD() {
     return kDEntry.getDouble(0);
   }
 
-    /** Get acceleration gain (A)
-     * 
-     */
+  /** Get acceleration gain (A) */
   public double getA() {
     return kAEntry != null ? kAEntry.getDouble(0) : 0;
   }
 
-    /** Get velocity gain (V)
-     * 
-     */
+  /** Get velocity gain (V) */
   public double getV() {
     return kVEntry != null ? kVEntry.getDouble(0) : 0;
   }
 
-    /** Get static gain (S)
-     * 
-     */
+  /** Get static gain (S) */
   public double getS() {
     return kSEntry != null ? kSEntry.getDouble(0) : 0;
   }
 
-    /** Get gravity gain (G)
-     * 
-     */
+  /** Get gravity gain (G) */
   public double getG() {
     return kGEntry != null ? kGEntry.getDouble(0) : 0;
   }
 
-  /** Check if any gains have changed using the current values from the subsystem.
-   * Compares all gains: P, I, D, A, V, S, G
+  /**
+   * Check if any gains have changed using the current values from the subsystem. Compares all
+   * gains: P, I, D, A, V, S, G
    */
   public boolean anyGainsChanged(
       double currentP,
@@ -140,8 +121,9 @@ public class GainsTuningEntry {
         || currentA != getA());
   }
 
-  /** Check if any gains have changed using the current values from the subsystem.
-   * Compares P, I, D, V, S, G
+  /**
+   * Check if any gains have changed using the current values from the subsystem. Compares P, I, D,
+   * V, S, G
    */
   public boolean pidffGainsChanged(
       double currentP,
@@ -157,8 +139,9 @@ public class GainsTuningEntry {
         || currentG != getG());
   }
 
-  /** Check if any gains have changed using the current values from the subsystem.
-   * Compares P, I, D only
+  /**
+   * Check if any gains have changed using the current values from the subsystem. Compares P, I, D
+   * only
    */
   public boolean pidGainsChanged(double currentP, double currentI, double currentD) {
 

--- a/src/main/java/frc/robot/util/GainsTuningEntry.java
+++ b/src/main/java/frc/robot/util/GainsTuningEntry.java
@@ -15,7 +15,6 @@ public class GainsTuningEntry {
   private NetworkTableEntry kVEntry;
   private NetworkTableEntry kSEntry;
   private NetworkTableEntry kGEntry;
-  public boolean updated = true;
 
   /* Base PID Feedback entires. Excludes kA, kV, kS, and kG
    *
@@ -76,18 +75,22 @@ public class GainsTuningEntry {
     return kSubsystemName;
   }
 
+  // Get proportional gain (P)
   public double getP() {
     return kPEntry.getDouble(0);
   }
 
+  // Get integral gain (I)
   public double getI() {
     return kIEntry.getDouble(0);
   }
 
+  // Get derivative gain (D)
   public double getD() {
     return kDEntry.getDouble(0);
   }
 
+  // Get acceleration gain (A)
   public double getA() {
     if (kAEntry == null) {
       return 0;
@@ -96,6 +99,7 @@ public class GainsTuningEntry {
     }
   }
 
+  // Get velocity gain (V)
   public double getV() {
     if (kVEntry == null) {
       return 0;
@@ -104,6 +108,7 @@ public class GainsTuningEntry {
     }
   }
 
+  // Get static gain (S)
   public double getS() {
     if (kSEntry == null) {
       return 0;
@@ -112,11 +117,60 @@ public class GainsTuningEntry {
     }
   }
 
+  // Get gravity gain (G)
   public double getG() {
     if (kGEntry == null) {
       return 0;
     } else {
       return kGEntry.getDouble(0);
     }
+  }
+
+  /* Check if any gains have changed using the current values from the subsystem.
+   * Compares all gains: P, I, D, A, V, S, G
+   */
+  public boolean anyGainsChanged(
+      double currentP,
+      double currentI,
+      double currentD,
+      double currentA,
+      double currentV,
+      double currentS,
+      double currentG) {
+
+    return (currentP != getP()
+        || currentI != getI()
+        || currentD != getD()
+        || currentA != getA()
+        || currentV != getV()
+        || currentS != getS()
+        || currentG != getG());
+  }
+
+  /* Check if any gains have changed using the current values from the subsystem.
+   * Compares P, I, D, V, S, G
+   */
+  public boolean pidffGainsChanged(
+      double currentP,
+      double currentI,
+      double currentD,
+      double currentV,
+      double currentS,
+      double currentG) {
+
+    return (currentP != getP()
+        || currentI != getI()
+        || currentD != getD()
+        || currentV != getV()
+        || currentS != getS()
+        || currentG != getG());
+  }
+
+  /* Check if any gains have changed using the current values from the subsystem.
+   * Compares P, I, D only
+   */
+  public boolean pidGainsChanged(double currentP, double currentI, double currentD) {
+
+    return (currentP != getP() || currentI != getI() || currentD != getD());
   }
 }

--- a/src/main/java/frc/robot/util/GainsTuningEntry.java
+++ b/src/main/java/frc/robot/util/GainsTuningEntry.java
@@ -15,12 +15,14 @@ public class GainsTuningEntry {
   private NetworkTableEntry kVEntry;
   private NetworkTableEntry kSEntry;
   private NetworkTableEntry kGEntry;
+  public boolean updated = true;
 
   /* Base PID Feedback entires. Excludes kA, kV, kS, and kG
    *
    */
-  public GainsTuningEntry(String SubsystemName, double kp, double ki, double kd) {
-    table = NetworkTableInstance.getDefault().getTable("Gains/" + SubsystemName);
+  public GainsTuningEntry(String subsystemName, double kp, double ki, double kd) {
+    table = NetworkTableInstance.getDefault().getTable("Gains/" + subsystemName);
+    this.kSubsystemName = subsystemName;
     kPEntry = table.getEntry("kP");
     kIEntry = table.getEntry("kI");
     kDEntry = table.getEntry("kD");
@@ -37,7 +39,7 @@ public class GainsTuningEntry {
    *
    */
   public GainsTuningEntry(
-      String SubsystemName,
+      String subsystemName,
       double kp,
       double ki,
       double kd,
@@ -45,7 +47,7 @@ public class GainsTuningEntry {
       double kv,
       double ks,
       double kg) {
-    this(SubsystemName, kp, ki, kd);
+    this(subsystemName, kp, ki, kd);
     kAEntry = table.getEntry("kA");
     kVEntry = table.getEntry("kV");
     kSEntry = table.getEntry("kS");
@@ -60,8 +62,8 @@ public class GainsTuningEntry {
    *
    */
   public GainsTuningEntry(
-      String SubsystemName, double kp, double ki, double kd, double kv, double ks, double kg) {
-    this(SubsystemName, kp, ki, kd);
+      String subsystemName, double kp, double ki, double kd, double kv, double ks, double kg) {
+    this(subsystemName, kp, ki, kd);
     kVEntry = table.getEntry("kV");
     kSEntry = table.getEntry("kS");
     kGEntry = table.getEntry("kG");
@@ -88,7 +90,7 @@ public class GainsTuningEntry {
 
   public double getA() {
     if (kAEntry == null) {
-      return -1;
+      return 0;
     } else {
       return kAEntry.getDouble(0);
     }
@@ -96,7 +98,7 @@ public class GainsTuningEntry {
 
   public double getV() {
     if (kVEntry == null) {
-      return -1;
+      return 0;
     } else {
       return kVEntry.getDouble(0);
     }
@@ -104,7 +106,7 @@ public class GainsTuningEntry {
 
   public double getS() {
     if (kSEntry == null) {
-      return -1;
+      return 0;
     } else {
       return kSEntry.getDouble(0);
     }
@@ -112,7 +114,7 @@ public class GainsTuningEntry {
 
   public double getG() {
     if (kGEntry == null) {
-      return -1;
+      return 0;
     } else {
       return kGEntry.getDouble(0);
     }

--- a/src/main/java/frc/robot/util/GainsTuningEntry.java
+++ b/src/main/java/frc/robot/util/GainsTuningEntry.java
@@ -1,0 +1,120 @@
+package frc.robot.util;
+
+import edu.wpi.first.networktables.NetworkTable;
+import edu.wpi.first.networktables.NetworkTableEntry;
+import edu.wpi.first.networktables.NetworkTableInstance;
+
+public class GainsTuningEntry {
+
+  private final NetworkTable table;
+  private String kSubsystemName;
+  private NetworkTableEntry kPEntry;
+  private NetworkTableEntry kIEntry;
+  private NetworkTableEntry kDEntry;
+  private NetworkTableEntry kAEntry;
+  private NetworkTableEntry kVEntry;
+  private NetworkTableEntry kSEntry;
+  private NetworkTableEntry kGEntry;
+
+  /* Base PID Feedback entires. Excludes kA, kV, kS, and kG
+   *
+   */
+  public GainsTuningEntry(String SubsystemName, double kp, double ki, double kd) {
+    table = NetworkTableInstance.getDefault().getTable("Gains/" + SubsystemName);
+    kPEntry = table.getEntry("kP");
+    kIEntry = table.getEntry("kI");
+    kDEntry = table.getEntry("kD");
+    kAEntry = null;
+    kVEntry = null;
+    kSEntry = null;
+    kGEntry = null;
+    kPEntry.setDouble(kp);
+    kIEntry.setDouble(ki);
+    kDEntry.setDouble(kd);
+  }
+
+  /* With ALL Feedback + Feedforward entries, INCLUDING kA
+   *
+   */
+  public GainsTuningEntry(
+      String SubsystemName,
+      double kp,
+      double ki,
+      double kd,
+      double ka,
+      double kv,
+      double ks,
+      double kg) {
+    this(SubsystemName, kp, ki, kd);
+    kAEntry = table.getEntry("kA");
+    kVEntry = table.getEntry("kV");
+    kSEntry = table.getEntry("kS");
+    kGEntry = table.getEntry("kG");
+    kAEntry.setDouble(ka);
+    kVEntry.setDouble(kv);
+    kSEntry.setDouble(ks);
+    kGEntry.setDouble(kg);
+  }
+
+  /* With Feedback + Feedforward entries, except kA
+   *
+   */
+  public GainsTuningEntry(
+      String SubsystemName, double kp, double ki, double kd, double kv, double ks, double kg) {
+    this(SubsystemName, kp, ki, kd);
+    kVEntry = table.getEntry("kV");
+    kSEntry = table.getEntry("kS");
+    kGEntry = table.getEntry("kG");
+    kVEntry.setDouble(kv);
+    kSEntry.setDouble(ks);
+    kGEntry.setDouble(kg);
+  }
+
+  public String getSubsystem() {
+    return kSubsystemName;
+  }
+
+  public double getP() {
+    return kPEntry.getDouble(0);
+  }
+
+  public double getI() {
+    return kIEntry.getDouble(0);
+  }
+
+  public double getD() {
+    return kDEntry.getDouble(0);
+  }
+
+  public double getA() {
+    if (kAEntry == null) {
+      return -1;
+    } else {
+      return kAEntry.getDouble(0);
+    }
+  }
+
+  public double getV() {
+    if (kVEntry == null) {
+      return -1;
+    } else {
+      return kVEntry.getDouble(0);
+    }
+  }
+
+  public double getS() {
+    if (kSEntry == null) {
+      return -1;
+    } else {
+      return kSEntry.getDouble(0);
+    }
+  }
+
+  public double getG() {
+    if (kGEntry == null) {
+      return -1;
+    } else {
+      return kGEntry.getDouble(0);
+    }
+  }
+}


### PR DESCRIPTION
A network tables based class to assist in PID tuning. Can be dropped into any subsystem and fully utilized in like 10 lines of code. Use case showed in armPivot changes.

Has a constructor for:

P,I,D config (Basic PID)
P,I,D,K,S,V,G config (certain control types for Talon FX motors do not allow for kA, so I made a constructor w/o it)
P,I,D,K,S,A,V,G config (every feedback & feedforward constant)
